### PR TITLE
Allow type-conversion in pandas_opts options to the csv storage

### DIFF
--- a/examples/read-csv/python-storage-plugins/csv.py
+++ b/examples/read-csv/python-storage-plugins/csv.py
@@ -2,6 +2,7 @@
 import re
 import warnings
 import hashlib
+import ast
 from pathlib import Path
 
 import pandas as pd
@@ -29,10 +30,9 @@ class csv(DLiteStorageBase):  # noqa: F821
             Additional search directories to add to the search path for
             `meta`.  Optional
         pandas_opts: string
-            Comma-separated string of key=value options sent to pandas
-            read_<format> or save_<format> function.
-            Values containing commas may be quoted with either single
-            or double quotes.
+            Comma-separated string of "key"=value options sent to pandas
+            read_<format> or save_<format> function.  String values should
+            be quoted.
         format: "csv" | "excel" | "json" | "clipboard", ...
             Any format supported by pandas.  The default is inferred from
             the extension of `uri`.
@@ -140,12 +140,10 @@ def infer_meta(data, metauri, uri):
 
 
 def optstring2keywords(optstring):
-    """Converts comma-separated ``key=value`` option string `optstring` to
-    a keyword dict and return it.  Values containing commas may be
-    quoted with either single or double quotes.
+    """Converts comma-separated ``"key":value`` option string `optstring`
+    to a keyword dict and return it.
+
+    The values should be valid Python expressions.  They are parsed with
+    ast.literal_eval().
     """
-    d = {}
-    for key, a, b, c in re.findall(
-            '([^=]+)=([^"\',]+|"([^"]*)"|\'([^\']*)\'),?', optstring):
-        d[key] = c if c else b if b else a
-    return d
+    return ast.literal_eval('{%s}' % optstring)

--- a/examples/read-csv/python-storage-plugins/csv.py
+++ b/examples/read-csv/python-storage-plugins/csv.py
@@ -1,4 +1,5 @@
 """Storage plugin that reading/writing CSV files."""
+import sys
 import re
 import warnings
 import hashlib
@@ -146,4 +147,10 @@ def optstring2keywords(optstring):
     The values should be valid Python expressions.  They are parsed with
     ast.literal_eval().
     """
-    return ast.literal_eval('{%s}' % optstring)
+    s = '{%s}' % (optstring, )
+    try:
+        return ast.literal_eval(s)
+    except:
+        exc, val, tr = sys.exc_info()
+        raise ValueError(
+            f'invalid in option string ({exc.__name__}): {optstring!r}')

--- a/examples/read-csv/readcsv.py
+++ b/examples/read-csv/readcsv.py
@@ -13,7 +13,8 @@ print(csv.uuid)
 csv.save('csv:newfile.csv')
 
 # Try to use the pandas hdf writer...
-csv.save('csv:newfile.h5?pandas_opts="key":"group"')
+csv.save('csv:newfile.h5?pandas_opts="key": "group", "index": False')
+
 
 # ... or excel writer (requires openpyxl)
 try:

--- a/examples/read-csv/readcsv.py
+++ b/examples/read-csv/readcsv.py
@@ -13,7 +13,7 @@ print(csv.uuid)
 csv.save('csv:newfile.csv')
 
 # Try to use the pandas hdf writer...
-csv.save('csv:newfile.h5?pandas_opts=key=group')
+csv.save('csv:newfile.h5?pandas_opts="key":"group"')
 
 # ... or excel writer (requires openpyxl)
 try:

--- a/storages/python/python-storage-plugins/csv.py
+++ b/storages/python/python-storage-plugins/csv.py
@@ -2,6 +2,7 @@
 import re
 import warnings
 import hashlib
+import ast
 from pathlib import Path
 
 import pandas as pd
@@ -29,10 +30,9 @@ class csv(DLiteStorageBase):  # noqa: F821
             Additional search directories to add to the search path for
             `meta`.  Optional
         pandas_opts: string
-            Comma-separated string of key=value options sent to pandas
-            read_<format> or save_<format> function.
-            Values containing commas may be quoted with either single
-            or double quotes.
+            Comma-separated string of "key"=value options sent to pandas
+            read_<format> or save_<format> function.  String values should
+            be quoted.
         format: "csv" | "excel" | "json" | "clipboard", ...
             Any format supported by pandas.  The default is inferred from
             the extension of `uri`.
@@ -140,12 +140,10 @@ def infer_meta(data, metauri, uri):
 
 
 def optstring2keywords(optstring):
-    """Converts comma-separated ``key=value`` option string `optstring` to
-    a keyword dict and return it.  Values containing commas may be
-    quoted with either single or double quotes.
+    """Converts comma-separated ``"key":value`` option string `optstring`
+    to a keyword dict and return it.
+
+    The values should be valid Python expressions.  They are parsed with
+    ast.literal_eval().
     """
-    d = {}
-    for key, a, b, c in re.findall(
-            '([^=]+)=([^"\',]+|"([^"]*)"|\'([^\']*)\'),?', optstring):
-        d[key] = c if c else b if b else a
-    return d
+    return ast.literal_eval('{%s}' % optstring)

--- a/storages/python/python-storage-plugins/csv.py
+++ b/storages/python/python-storage-plugins/csv.py
@@ -1,4 +1,5 @@
 """Storage plugin that reading/writing CSV files."""
+import sys
 import re
 import warnings
 import hashlib
@@ -146,4 +147,10 @@ def optstring2keywords(optstring):
     The values should be valid Python expressions.  They are parsed with
     ast.literal_eval().
     """
-    return ast.literal_eval('{%s}' % optstring)
+    s = '{%s}' % (optstring, )
+    try:
+        return ast.literal_eval(s)
+    except:
+        exc, val, tr = sys.exc_info()
+        raise ValueError(
+            f'invalid in option string ({exc.__name__}): {optstring!r}')


### PR DESCRIPTION
Changes the syntax of pandas_opts to a comma-separated list of `"key":value` pairs. `value` may be any basic python expression.
