### PR TITLE
Remove globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img src="doc/figs/logo.svg" align="right" />
 
+
 DLite
 =====
 > Lightweight data-centric framework for working with scientific data

--- a/examples/ex2/CMakeLists.txt
+++ b/examples/ex2/CMakeLists.txt
@@ -6,26 +6,25 @@ project(dlite-example-2
   VERSION 0.1
   LANGUAGES C)
 
-#set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
-#include(Finddlite)
+set(CMAKE_MODULE_PATH
+  ${CMAKE_MODULE_PATH}
+  ${DLITE_ROOT}/cmake
+  ${DLITE_ROOT}/cmake/Modules
+  ${DLITE_ROOT}/share/cmake
+  ${DLITE_ROOT}/share/cmake/Modules
+  )
 find_package(dlite REQUIRED)
 
-add_compile_options("-DDLITE_ROOT=${DLITE_ROOT}")
+include(dliteCodeGen)
 
-add_custom_command(
-  OUTPUT chemistry.h
-  COMMAND
-    ${CMAKE_COMMAND} -E env
-    LD_LIBRARY_PATH="${DLITE_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}"
-    DLITE_STORAGE_PLUGIN_DIRS="${DLITE_STORAGE_PLUGIN_DIRS}"
-    ${DLITE_ROOT}/bin/dlite-codegen
-      --format=c-header
-      --output=chemistry.h
-      --storage-plugins="${DLITE_STORAGE_PLUGIN_DIRS}"
-      json://${CMAKE_CURRENT_SOURCE_DIR}/Chemistry-0.1.json?mode=r
-  MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/Chemistry-0.1.json
-  COMMENT "Generating C header for Chemistry-0.1.json"
+dlite_codegen(
+  ${CMAKE_CURRENT_BINARY_DIR}/chemistry.h
+  c-header
+  json://${CMAKE_CURRENT_SOURCE_DIR}/Chemistry-0.1.json
+  --storage-plugins=${DLITE_STORAGE_PLUGINS}
   )
+
+add_compile_options("-DDLITE_ROOT=${DLITE_ROOT}")
 
 link_directories(${DLITE_LIBRARY_DIR})
 
@@ -42,6 +41,7 @@ enable_testing()
 add_test(
   NAME dlite-example-2
   COMMAND ${CMAKE_CURRENT_BINARY_DIR}/dlite-example-2
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
 set_property(TEST dlite-example-2 PROPERTY

--- a/src/dlite-codegen.c
+++ b/src/dlite-codegen.c
@@ -34,13 +34,6 @@ typedef struct {
   int use_native_typenames;
 } Globals;
 
-// /* Global variable indicating whether native typenames should be used.
-//    The default is to use portable type names. */
-// int dlite_codegen_use_native_typenames = 0;
-//
-// /* Pointer to template paths.  Access it via dlite_codegen_path_get(). */
-// static FUPaths *template_paths = NULL;
-
 
 /* Free global state for this module */
 static void free_globals(void *globals)

--- a/src/dlite-codegen.c
+++ b/src/dlite-codegen.c
@@ -13,6 +13,7 @@
 #include "dlite-macros.h"
 #include "dlite-codegen.h"
 
+#define GLOBALS_ID "dlite-codegen-globals-id"
 
 
 /* Context for looping over properties */
@@ -22,14 +23,47 @@ typedef struct {
   int metameta;               /* whether to list inst->meta instead of inst */
 }  Context;
 
+typedef struct {
+  /* Pointer to template paths.  Access it via dlite_codegen_path_get(). */
+  FUPaths template_paths;
 
-/* Global variable indicating whether native typenames should be used.
-   The default is to use portable type names. */
-int dlite_codegen_use_native_typenames = 0;
+  /* Whether template_paths are initialised */
+  int template_paths_initialised;
 
-/* Pointer to template paths.  Access it via dlite_codegen_path_get(). */
-static FUPaths *template_paths = NULL;
+  /* Whether native typenames should be used.  Defaults to portable type names. */
+  int use_native_typenames;
+} Globals;
 
+// /* Global variable indicating whether native typenames should be used.
+//    The default is to use portable type names. */
+// int dlite_codegen_use_native_typenames = 0;
+//
+// /* Pointer to template paths.  Access it via dlite_codegen_path_get(). */
+// static FUPaths *template_paths = NULL;
+
+
+/* Free global state for this module */
+static void free_globals(void *globals)
+{
+  Globals *g = globals;
+  dlite_codegen_path_free();
+  free(g);
+}
+
+/* Return a pointer to global state for this module */
+static Globals *get_globals(void)
+{
+  Globals *g = dlite_globals_get_state(GLOBALS_ID);
+  if (!g) {
+    if (!(g = calloc(1, sizeof(Globals)))) FAIL("allocation failure");
+
+    dlite_globals_add_state(GLOBALS_ID, g, free_globals);
+  }
+  return g;
+ fail:
+  if (g) free(g);
+  return NULL;
+}
 
 
 /* Generator function that simply copies the template.
@@ -152,6 +186,7 @@ static int list_properties_helper(TGenBuf *s, const char *template, int len,
                                   TGenSubs *subs, void *context,
                                   int metameta)
 {
+  Globals *g = get_globals();
   int retval = 0;
   const DLiteMeta *meta = (const DLiteMeta *)((Context *)context)->inst;
   const DLiteMeta *m = (metameta) ? meta->meta : meta;
@@ -182,7 +217,7 @@ static int list_properties_helper(TGenBuf *s, const char *template, int len,
     char *iri = (p->iri) ? p->iri : "";
     dlite_type_set_typename(p->type, p->size, typename, sizeof(typename));
     dlite_type_set_cdecl(p->type, p->size, p->name, nref, pcdecl,
-			 sizeof(pcdecl), dlite_codegen_use_native_typenames);
+			 sizeof(pcdecl), g->use_native_typenames);
     dlite_type_set_ftype(p->type, p->size, ftype, sizeof(ftype));
     dlite_type_set_isoctype(p->type, p->size, isoctype, sizeof(isoctype));
 
@@ -454,31 +489,47 @@ int dlite_option_subs(TGenSubs *subs, const char *options)
 /* Returns a pointer to current template paths. */
 FUPaths *dlite_codegen_path_get(void)
 {
-  if (!template_paths) {
-    static FUPaths paths;
+  Globals *g = get_globals();
+  if (!g->template_paths_initialised) {
+    if (fu_paths_init(&g->template_paths, "DLITE_TEMPLATE_DIRS") < 0)
+      return errx(1, "failure initialising codegen template paths"), NULL;
 
-    if (fu_paths_init(&paths, "DLITE_TEMPLATE_DIRS") < 0)
-      return err(1, "failure initialising codegen template paths"), NULL;
-
-    fu_paths_set_platform(&paths, dlite_get_platform());
+    fu_paths_set_platform(&g->template_paths, dlite_get_platform());
 
     if (dlite_use_build_root())
-      fu_paths_extend(&paths, dlite_TEMPLATES, NULL);
+      fu_paths_extend(&g->template_paths, dlite_TEMPLATES, NULL);
     else
-      fu_paths_extend_prefix(&paths, dlite_root_get(),
+      fu_paths_extend_prefix(&g->template_paths, dlite_root_get(),
                              DLITE_TEMPLATE_DIRS, NULL);
 
-    atexit(dlite_codegen_path_free);
-    template_paths = &paths;
+    g->template_paths_initialised = 1;
   }
-  return template_paths;
+  return &g->template_paths;
 }
 
 /* Free template paths */
 void dlite_codegen_path_free(void)
 {
-  if (template_paths) fu_paths_deinit(template_paths);
-  template_paths = NULL;
+  Globals *g = get_globals();
+  if (g->template_paths_initialised) {
+    fu_paths_deinit(&g->template_paths);
+    g->template_paths_initialised = 1;
+  }
+}
+
+/* Returns whether to use native typenames */
+int dlite_codegen_get_native_typenames(void)
+{
+  Globals *g = get_globals();
+  return g->use_native_typenames;
+}
+
+
+/* Sets whether to use native typenames. If zero, use portable type names. */
+void dlite_codegen_set_native_typenames(int use_native_typenames)
+{
+  Globals *g = get_globals();
+  g->use_native_typenames = use_native_typenames;
 }
 
 

--- a/src/dlite-codegen.h
+++ b/src/dlite-codegen.h
@@ -14,12 +14,6 @@
 
 
 /**
-  Global variable indicating whether native typenames should be used.
-  The default is to use portable type names.
-*/
-extern int dlite_codegen_use_native_typenames;
-
-/**
   Assign/update substitutions based on the instance `inst`.
 
   Returns non-zero on error.
@@ -44,6 +38,17 @@ FUPaths *dlite_codegen_path_get(void);
   Free up memory in template paths.
 */
 void dlite_codegen_path_free(void);
+
+
+/**
+  Returns whether to use native typenames
+*/
+int dlite_codegen_get_native_typenames(void);
+
+/**
+  Sets whether to use native typenames. If zero, use portable type names.
+*/
+  void dlite_codegen_set_native_typenames(int use_native_typenames);
 
 
 /**

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -73,7 +73,7 @@ static void _instance_store_addmeta(instance_map_t *istore,
 /* Returns pointer to instance store. */
 static instance_map_t *_instance_store(void)
 {
-  instance_map_t *istore = dlite_globals_get_state("instance-store");
+  instance_map_t *istore = dlite_globals_get_state("dlite-instance-store");
   if (!istore) {
     if (!(istore = malloc(sizeof(instance_map_t))))
       return err(1, "allocation failure"), NULL;
@@ -81,7 +81,8 @@ static instance_map_t *_instance_store(void)
     _instance_store_addmeta(istore, dlite_get_basic_metadata_schema());
     _instance_store_addmeta(istore, dlite_get_entity_schema());
     _instance_store_addmeta(istore, dlite_get_collection_entity());
-    dlite_globals_add_state("instance-store", istore, _instance_store_free);
+    dlite_globals_add_state("dlite-instance-store", istore,
+                            _instance_store_free);
   }
   return istore;
 }

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -65,8 +65,7 @@ typedef map_t(DLiteInstance *) instance_map_t;
 static instance_map_t *_instance_store = NULL;
 
 
-/* Frees up a global instance store.  Will be called at program exit,
-   but can be called at any time. */
+/* Creates global instance store.  */
 static void _instance_store_create(void)
 {
   if (!_instance_store) {

--- a/src/dlite-mapping-plugins.c
+++ b/src/dlite-mapping-plugins.c
@@ -50,7 +50,8 @@ static Globals *get_globals(void) {
 
     g->mapping_plugin_info = plugin_info_create("mapping-plugin",
                                                 "get_dlite_mapping_api",
-                                                "DLITE_MAPPING_PLUGIN_DIRS");
+                                                "DLITE_MAPPING_PLUGIN_DIRS",
+                                                dlite_globals_get());
     if (!g->mapping_plugin_info) goto fail;
 
     fu_paths_set_platform(&g->mapping_plugin_info->paths, dlite_get_platform());
@@ -195,7 +196,7 @@ dlite_mapping_plugin_next(DLiteMappingPluginIter *iter)
     return api;
   if (!iter->stop) {
     int n = iter->n;
-    api = dlite_python_mapping_next(&iter->n);
+    api = dlite_python_mapping_next(dlite_globals_get(), &iter->n);
     if (iter->n == n) iter->stop = 1;
   }
   return api;

--- a/src/dlite-mapping-plugins.c
+++ b/src/dlite-mapping-plugins.c
@@ -15,51 +15,68 @@
 
 #include "dlite-datamodel.h"
 #include "dlite-mapping-plugins.h"
+#include "dlite-macros.h"
 #ifdef WITH_PYTHON
 #include "pyembed/dlite-python-mapping.h"
 #endif
 
-/* Global reference to mapping plugin info */
-static PluginInfo *mapping_plugin_info = NULL;
-
-/* Sha256 hash of plugin paths */
-static unsigned char mapping_plugin_path_hash[32];
+#define GLOBALS_ID "dlite-mapping-plugins-id"
 
 
-/* Frees up `mapping_plugin_info`. */
-static void mapping_plugin_info_free(void)
+typedef struct {
+  /* Global reference to mapping plugin info */
+  PluginInfo *mapping_plugin_info;
+
+  /* Sha256 hash of plugin paths */
+  unsigned char mapping_plugin_path_hash[32];
+} Globals;
+
+
+/* Free global state for this module */
+static void free_globals(void *globals)
 {
-  if (mapping_plugin_info) {
-    PluginIter iter;
-    plugin_api_iter_init(&iter, mapping_plugin_info);
-    plugin_info_free(mapping_plugin_info);
+  Globals *g = globals;
+  if (g->mapping_plugin_info) {
+    plugin_info_free(g->mapping_plugin_info);
   }
-  mapping_plugin_info = NULL;
+  free(g);
 }
 
+/* Return a pointer to global state for this module */
+static Globals *get_globals(void) {
+  Globals *g = dlite_globals_get_state(GLOBALS_ID);
+  if (!g) {
+    if (!(g = calloc(1, sizeof(Globals)))) FAIL("allocation failure");
 
-/* Returns a pointer to `mapping_plugin_info`. */
-static PluginInfo *get_mapping_plugin_info(void)
-{
-  if (!mapping_plugin_info &&
-      (mapping_plugin_info =
-       plugin_info_create("mapping-plugin",
-                          "get_dlite_mapping_api",
-                          "DLITE_MAPPING_PLUGIN_DIRS"))) {
-    atexit(mapping_plugin_info_free);
+    g->mapping_plugin_info = plugin_info_create("mapping-plugin",
+                                                "get_dlite_mapping_api",
+                                                "DLITE_MAPPING_PLUGIN_DIRS");
+    if (!g->mapping_plugin_info) goto fail;
 
-    fu_paths_set_platform(&mapping_plugin_info->paths, dlite_get_platform());
+    fu_paths_set_platform(&g->mapping_plugin_info->paths, dlite_get_platform());
 
     if (dlite_use_build_root())
-      plugin_path_extend(mapping_plugin_info, dlite_MAPPING_PLUGINS, NULL);
+      plugin_path_extend(g->mapping_plugin_info, dlite_MAPPING_PLUGINS, NULL);
     else
-      plugin_path_extend_prefix(mapping_plugin_info, dlite_root_get(),
+      plugin_path_extend_prefix(g->mapping_plugin_info, dlite_root_get(),
                                 DLITE_ROOT "/" DLITE_MAPPING_PLUGIN_DIRS, NULL);
 
     /* Make sure that dlite DLLs are added to the library search path */
     dlite_add_dll_path();
+
+    dlite_globals_add_state(GLOBALS_ID, g, free_globals);
   }
-  return mapping_plugin_info;
+  return g;
+ fail:
+  if (g) free(g);
+  return NULL;
+}
+
+/* Returns a pointer to `mapping_plugin_info`. */
+static PluginInfo *get_mapping_plugin_info(void)
+{
+  Globals *g = get_globals();
+  return (g) ? g->mapping_plugin_info : NULL;
 }
 
 /* Loads all plugins (if we haven't done that before) */
@@ -70,13 +87,15 @@ static void load_mapping_plugins(void)
   const char *path;
   const unsigned char *hash;
   sha3_context c;
+  Globals *g;
 
 #ifdef WITH_PYTHON
   dlite_python_mapping_load();
 #endif
 
   // FIXME - use pathshash() instead
-  if (!(info = get_mapping_plugin_info())) return;
+  if (!(g = get_globals())) return;
+  if (!(info = g->mapping_plugin_info)) return;
   if (!(iter = fu_pathsiter_init(&info->paths, NULL))) return;
   sha3_Init256(&c);
   while ((path = fu_pathsiter_next(iter)))
@@ -85,9 +104,9 @@ static void load_mapping_plugins(void)
   hash = sha3_Finalize(&c);
   fu_pathsiter_deinit(iter);
 
-  if (memcmp(hash, mapping_plugin_path_hash, 32) != 0) {
+  if (memcmp(hash, g->mapping_plugin_path_hash, 32) != 0) {
     plugin_load_all(info);
-    memcpy(mapping_plugin_path_hash, hash, 32);
+    memcpy(g->mapping_plugin_path_hash, hash, 32);
   }
 }
 

--- a/src/dlite-misc.h
+++ b/src/dlite-misc.h
@@ -137,6 +137,13 @@ typedef struct _DLiteOpt {
  */
 int dlite_option_parse(char *options, DLiteOpt *opts, int modify);
 
+/** @} */
+
+
+/**
+  @name Path handling
+  @{
+ */
 
 /**
   Returns a newly allocated url constructed from the arguments of the form
@@ -223,10 +230,55 @@ const char *dlite_root_get(void);
  */
 int dlite_add_dll_path(void);
 
+/** @} */
+
+
+/**
+  @name Managing global state
+  @{
+*/
+
+/**
+  Globals handle.
+ */
+typedef struct _Session DLiteGlobals;
+
+/**
+  Returns reference to globals handle.
+*/
+DLiteGlobals *dlite_globals_get(void);
+
+/**
+  Set globals handle.
+*/
+void dlite_globals_set(DLiteGlobals *);
+
+/**
+  Add global state with given name.
+
+  `ptr` is a pointer to the state and `free_fun` is a function that frees it.
+  Returns non-zero on error.
+ */
+int dlite_globals_add_state(const char *name, void *ptr,
+                            void (*free_fun)(void *ptr));
+
+/**
+  Remove global state with the given name.
+  Returns non-zero on error.
+ */
+int dlite_globals_remove_state(const char *name);
+
+/**
+  Returns global state with given name or NULL on error.
+ */
+void *dlite_globals_get_state(const char *name);
+
+/** @} */
 
 
 /**
   @name Wrappers around error functions
+  @{
 */
 #ifndef __GNUC__
 #define __attribute__(x)

--- a/src/dlite-misc.h
+++ b/src/dlite-misc.h
@@ -251,7 +251,7 @@ DLiteGlobals *dlite_globals_get(void);
 /**
   Set globals handle.
 */
-void dlite_globals_set(DLiteGlobals *);
+void dlite_globals_set(DLiteGlobals *globals_handler);
 
 /**
   Add global state with given name.

--- a/src/dlite-misc.h
+++ b/src/dlite-misc.h
@@ -273,6 +273,11 @@ int dlite_globals_remove_state(const char *name);
  */
 void *dlite_globals_get_state(const char *name);
 
+/**
+  Returns non-zero if we are in an atexit handler.
+ */
+int dlite_globals_in_atexit(void);
+
 /** @} */
 
 

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -55,11 +55,13 @@ static PluginInfo *get_storage_plugin_info(void)
 {
   Globals *g;
   if (!(g = get_globals())) return NULL;
+
   if (!g->storage_plugin_info &&
       (g->storage_plugin_info =
        plugin_info_create("storage-plugin",
 			  "get_dlite_storage_plugin_api",
-			  "DLITE_STORAGE_PLUGIN_DIRS"))) {
+			  "DLITE_STORAGE_PLUGIN_DIRS",
+                          dlite_globals_get()))) {
     fu_paths_set_platform(&g->storage_plugin_info->paths, dlite_get_platform());
     if (dlite_use_build_root())
       plugin_path_extend(g->storage_plugin_info, dlite_STORAGE_PLUGINS, NULL);

--- a/src/dlite-storage-plugins.h
+++ b/src/dlite-storage-plugins.h
@@ -86,7 +86,8 @@ struct _DLiteDataModel {
   plugins exposing several APIs.  If the plugin has more APIs to
   expose, it should increase the integer pointed to by `iter` by one.
  */
-typedef const DLiteStoragePlugin *(*GetDLiteStorageAPI)(int *iter);
+typedef const DLiteStoragePlugin *(*GetDLiteStorageAPI)(DLiteGlobals *g,
+                                                        int *iter);
 
 
 /**

--- a/src/pyembed/dlite-python-mapping.h
+++ b/src/pyembed/dlite-python-mapping.h
@@ -65,10 +65,12 @@ void dlite_python_mapping_unload(void);
   Returns pointer to next Python mapping plugin (casted to void *) or
   NULL on error.
 
+  `state` should be a pointer to the global state.
+
   At the first call to this function, `*iter` should be initialised to zero.
   If there are more APIs, `*iter` will be increased by one.
 */
-const void *dlite_python_mapping_next(int *iter);
+const void *dlite_python_mapping_next(void *state, int *iter);
 
 /**
   Returns Python mapping plugin (casted to void *) with given name or

--- a/src/pyembed/dlite-python-storage.c
+++ b/src/pyembed/dlite-python-storage.c
@@ -33,7 +33,7 @@ typedef struct {
 } PythonStorageGlobals;
 
 
-/* Return a pointer to global state for this module */
+/* Free global state for this module */
 static void free_globals(void *globals)
 {
   PythonStorageGlobals *g = (PythonStorageGlobals *)globals;
@@ -41,6 +41,8 @@ static void free_globals(void *globals)
 
   /* Do not call Py_DECREF if we are in an atexit handler */
   if (!dlite_globals_in_atexit()) Py_XDECREF(g->loaded_storages);
+
+  free(g);
 }
 
 

--- a/src/tests/mappings/mapA.c
+++ b/src/tests/mappings/mapA.c
@@ -36,11 +36,13 @@ DLiteInstance *mapper(const DLiteMappingPlugin *api,
 }
 
 
-DSL_EXPORT const DLiteMappingPlugin *get_dlite_mapping_api(int *iter)
+DSL_EXPORT const DLiteMappingPlugin *get_dlite_mapping_api(void *state, int *iter)
 {
   static DLiteMappingPlugin api;
   static const char *input_uris[] = { "http://onto-ns.com/meta/0.1/ent1" };
   UNUSED(iter);
+
+  dlite_globals_set(state);
 
   api.name = "mapA";
   api.output_uri = "http://onto-ns.com/meta/0.1/ent2";

--- a/src/tests/test_triplestore.c
+++ b/src/tests/test_triplestore.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <errno.h>
 
+#include "utils/session.h"
 #include "minunit/minunit.h"
 #include "triplestore.h"
 
@@ -103,10 +104,11 @@ MU_TEST(test_remove)
 }
 
 
-
 MU_TEST(test_free)
 {
+  Session *s = session_get_default();
   triplestore_free(ts);
+  session_free(s);
 }
 
 

--- a/src/tests/test_triplestore.c
+++ b/src/tests/test_triplestore.c
@@ -106,8 +106,9 @@ MU_TEST(test_remove)
 
 MU_TEST(test_free)
 {
-  Session *s = session_get_default();
   triplestore_free(ts);
+
+  Session *s = session_get_default();
   session_free(s);
 }
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -261,6 +261,7 @@ set(sources
   infixcalc.c
   jsmnx.c
   jstore.c
+  session.c
 
   md5.c
   sha1.c

--- a/src/utils/map.h
+++ b/src/utils/map.h
@@ -56,6 +56,8 @@
       void map_remove(MAP_T *m, const char *key);
   Removes the mapping of the given key from the map. If the key
   does not exist in the map then the function has no effect.
+  Note: this function should not be called while iterating over
+  the map.
 
       map_iter_t map_iter(MAP_T *m);
   Returns a map_iter_t which can be used with map_next() to

--- a/src/utils/session.c
+++ b/src/utils/session.c
@@ -205,11 +205,10 @@ int session_remove_state(Session *s, const char *name)
 /*
   Retrieve global state corresponding to `name`
 
-  Return pointer to global state or NULL on error.
+  Return pointer to global state or NULL if no state with this name exists.
  */
 void *session_get_state(Session *s, const char *name)
 {
-  State *sp = map_get(&s->states, name);
-  if (!sp) return errx(1, "no such global state: %s", name), NULL;
-  return sp->ptr;
+  State *st = map_get(&s->states, name);
+  return (st) ? st->ptr : NULL;
 }

--- a/src/utils/session.c
+++ b/src/utils/session.c
@@ -151,7 +151,7 @@ Session *session_get_default(void)
 int session_set_default(Session *s)
 {
   map_session_t *sessions = get_sessions();
-  Session *s2 = session_get(DEFAULT_SESSION_ID);
+  Session *s2 = map_get(sessions, DEFAULT_SESSION_ID);
   if (s2 && s2 != s)
     return errx(1, "a default session has already been set");
   map_set(sessions, DEFAULT_SESSION_ID, *s);

--- a/src/utils/session.c
+++ b/src/utils/session.c
@@ -1,0 +1,215 @@
+#include <assert.h>
+#include "map.h"
+#include "err.h"
+#include "session.h"
+
+
+/* Convenient macros for failing */
+#define FAIL(msg) do { \
+    errx(1, msg); goto fail; } while (0)
+#define FAIL1(msg, a1) do { \
+    errx(1, msg, a1); goto fail; } while (0)
+
+
+#define DEFAULT_SESSION_ID ":default-session:"
+
+
+typedef struct _State {
+  void *ptr;
+  void (*free_fun)(void *ptr);
+} State;
+
+typedef map_t(State) map_state_t;
+
+
+struct _Session {
+  const char *session_id;
+  map_state_t states;
+};
+
+typedef map_t(Session) map_session_t;
+
+
+/* Global session store */
+static map_session_t _sessions;
+
+/* Number of sessions */
+static int _sessions_count=0;
+
+/* Returns pointer to `_sessions`.  Initialise it if needed. */
+static map_session_t *get_sessions(void)
+{
+  if (!_sessions_count)
+    map_init(&_sessions);
+  return &_sessions;
+}
+
+
+/*
+  Create a new session with given `session_id`.
+
+  Return pointer to the session or NULL on error.
+*/
+Session *session_create(const char *session_id)
+{
+  map_session_t *sessions = get_sessions();
+  Session s, *sp;
+  memset(&s, 0, sizeof(s));
+  if (map_get(sessions, session_id))
+    return errx(1, "cannot create new session with existing session id: %s",
+                session_id), NULL;
+  if (!(s.session_id = strdup(session_id)))
+    return err(1, "allocation failure"), NULL;
+  if (map_set(sessions, session_id, s))
+    return errx(1, "failed to create new session with id: %s", session_id), NULL;
+  map_init(&s.states);
+
+  sp = map_get(sessions, session_id);
+  assert(sp);
+  map_init(&sp->states);
+
+  _sessions_count++;
+  return sp;
+}
+
+/*
+  Free all memory associated with `session`.
+*/
+void session_free(Session *s)
+{
+  map_session_t *sessions = get_sessions();
+  map_iter_t iter = map_iter(&s->states);
+  const char *name, *id=s->session_id;
+
+  while ((name = map_next(&s->states, &iter))) {
+    State *st = map_get(&s->states, name);
+    if (st->free_fun) st->free_fun(st->ptr);
+  }
+  map_deinit(&s->states);
+
+  if (id) {
+    map_remove(sessions, id);
+    free((char *)id);
+  }
+
+  _sessions_count--;
+  if (!_sessions_count)
+    map_deinit(sessions);
+}
+
+/*
+  Retrieve session from `session_id`.
+
+  Return pointer to the session or NULL if no session exists with this id.
+*/
+Session *session_get(const char *session_id)
+{
+  map_session_t *sessions = get_sessions();
+  Session *s = map_get(sessions, session_id);
+  if (!s) return errx(1, "no session with id: %s", session_id), NULL;
+  return s;
+}
+
+
+/*
+  Retrive session id from session pointer.
+
+  Return session id or NULL on error.
+ */
+const char *session_get_id(Session *s)
+{
+  return s->session_id;
+}
+
+
+
+
+/*
+  Retrieve default session
+
+  A new default session will transparently be created if it does not already
+  exists.
+
+  Return pointer to default session or NULL on error.
+*/
+Session *session_get_default(void)
+{
+  map_session_t *sessions = get_sessions();
+  Session *s = map_get(sessions, DEFAULT_SESSION_ID);
+  if (!s) s = session_create(DEFAULT_SESSION_ID);
+  return s;
+}
+
+/*
+  Set default session
+
+  It is an error if a default session already exists which differs
+  from `s`.
+
+  Return non-zero on error.
+*/
+int session_set_default(Session *s)
+{
+  map_session_t *sessions = get_sessions();
+  Session *s2 = session_get(DEFAULT_SESSION_ID);
+  if (s2 && s2 != s)
+    return errx(1, "a default session has already been set");
+  map_set(sessions, DEFAULT_SESSION_ID, *s);
+  return 0;
+}
+
+
+/*
+  Add new global state
+
+  `s` - Pointer to session
+  `name` -  A new unique name associated with the state
+  `ptr` -  Pointer to state data
+  `free_fun` - Pointer to function that free state data
+
+  Return non-zero on error.
+ */
+int session_add_state(Session *s, const char *name, void *ptr,
+                           void (*free_fun)(void *ptr))
+{
+  State st, *sp;
+  memset(&st, 0, sizeof(st));
+
+  st.ptr = ptr;
+  st.free_fun = free_fun;
+  if (map_get(&s->states, name))
+    return errx(1, "cannot create existing state: %s", name);
+  map_set(&s->states, name, st);
+  sp = map_get(&s->states, name);
+  assert(sp);
+  assert(memcmp(sp, &st, sizeof(st)) == 0);
+  return 0;
+}
+
+/*
+  Remove global state with given name
+
+  `name` must refer to an existing state.
+
+  Return non-zero on error.
+ */
+int session_remove_state(Session *s, const char *name)
+{
+  State *st = map_get(&s->states, name);
+  if (!st) return errx(1, "no such global state: %s", name);
+  if (st->free_fun) st->free_fun(st->ptr);
+  map_remove(&s->states, name);
+  return 0;
+}
+
+/*
+  Retrieve global state corresponding to `name`
+
+  Return pointer to global state or NULL on error.
+ */
+void *session_get_state(Session *s, const char *name)
+{
+  State *sp = map_get(&s->states, name);
+  if (!sp) return errx(1, "no such global state: %s", name), NULL;
+  return sp->ptr;
+}

--- a/src/utils/session.c
+++ b/src/utils/session.c
@@ -212,3 +212,23 @@ void *session_get_state(Session *s, const char *name)
   State *st = map_get(&s->states, name);
   return (st) ? st->ptr : NULL;
 }
+
+/*
+  Dump a listing of all sessions to stdout.  For debugging
+ */
+void session_dump(void)
+{
+  map_iter_t iter = map_iter(&_sessions);
+  const char *session_id, *key;
+  while ((session_id = map_next(&_sessions, &iter))) {
+    Session *s = map_get(&_sessions, session_id);
+    map_iter_t stiter = map_iter(&s->states);
+    printf("SESSION %s: (%p)\n", session_id, (void *)s);
+    if (strcmp(s->session_id, session_id))
+      printf("  WARNING session id mismatch: %s\n", s->session_id);
+    while ((key = map_next(&s->states, &stiter))) {
+      State *st = map_get(&s->states, key);
+      printf("  - %s: %p\n", key, st->ptr);
+    }
+  }
+}

--- a/src/utils/session.h
+++ b/src/utils/session.h
@@ -1,0 +1,127 @@
+/* session.h -- simple session manager
+ *
+ * Copyright (c) 2021, SINTEF
+ *
+ * Distributed under terms of the MIT license.
+ */
+#ifndef _SESSION_H
+#define _SESSION_H
+
+/**
+  @file
+  @brief Simple session manager.
+
+  The purpose of this session manager is to maintain global states.
+  This library supports multiple sessions, but may also be used when you
+  only want to maintain a single global state.  Th this case, use
+  session_get_default() instead of session_create().
+ */
+
+
+/**
+  @brief Opaque session type.
+*/
+typedef struct _Session Session;
+
+
+/**
+  @name Creating, freeing and accessing sessions
+  @{
+*/
+
+/**
+  @brief Create a new session with given `session_id`.
+
+  @return Pointer to the session or NULL on error.
+*/
+Session *session_create(const char *session_id);
+
+/**
+  @brief Free all memory associated with `session`.
+*/
+void session_free(Session *s);
+
+/**
+  @brief Retrieve session from `session_id`.
+
+  @return Pointer to the session or NULL if no session exists with this id.
+*/
+Session *session_get(const char *session_id);
+
+/**
+  @brief Retrive session id from session pointer.
+
+  @return Session id or NULL on error.
+ */
+const char *session_get_id(Session *s);
+
+
+/**
+ @}
+
+ @name Accessing and setting default session
+
+ Useful these functions to maintain a single global state.
+ @{
+*/
+
+/**
+  @brief Retrieve default session
+
+  A new default session will transparently be created if it does not already
+  exists.
+
+  @return Pointer to default session or NULL on error.
+*/
+Session *session_get_default(void);
+
+/**
+  @brief Set default session
+
+  It is an error if a default session already exists which differs
+  from `s`.
+
+  @return Non-zero on error.
+*/
+int session_set_default(Session *s);
+
+
+/**
+ @}
+
+ @name Setting and accessing global states
+
+ Useful these functions to maintain a single global state.
+ @{
+*/
+
+/**
+  @brief Add new global state
+
+  @param s Pointer to session
+  @param name A new unique name associated with the state
+  @param ptr Pointer to state data
+  @param free_fun Pointer to function that free state data
+  @return Non-zero on error.
+ */
+int session_add_state(Session *s, const char *name, void *ptr,
+                           void (*free_fun)(void *ptr));
+
+/**
+  @brief Remove global state with given name
+
+  `name` must refer to an existing state.
+
+  @return Non-zero on error.
+ */
+int session_remove_state(Session *s, const char *name);
+
+/**
+  @brief Retrieve global state corresponding to `name`
+
+  @return Pointer to global state or NULL on error.
+ */
+void *session_get_state(Session *s, const char *name);
+
+
+#endif /*  _SESSION_H */

--- a/src/utils/session.h
+++ b/src/utils/session.h
@@ -123,5 +123,10 @@ int session_remove_state(Session *s, const char *name);
  */
 void *session_get_state(Session *s, const char *name);
 
+/**
+  Dump a listing of all sessions to stdout.  For debugging
+ */
+void session_dump(void);
+
 
 #endif /*  _SESSION_H */

--- a/src/utils/session.h
+++ b/src/utils/session.h
@@ -119,7 +119,7 @@ int session_remove_state(Session *s, const char *name);
 /**
   @brief Retrieve global state corresponding to `name`
 
-  @return Pointer to global state or NULL on error.
+  @return Pointer to global state or NULL if no state with this name exists.
  */
 void *session_get_state(Session *s, const char *name);
 

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(tests
   test_compat
   test_snprintf
   test_err
+  test_map
   test_strutils
   test_tmpfileplus
   test_strtob
@@ -23,6 +24,7 @@ set(tests
   test_infixcalc
   test_jsmnx
   test_jstore
+  test_session
 
   tgen_example
   )

--- a/src/utils/tests/test_map.c
+++ b/src/utils/tests/test_map.c
@@ -24,7 +24,8 @@ MU_TEST(test_map)
   iter = map_iter(&m);
   while ((key = map_next(&m, &iter))) {
     printf("%s -> %u\n", key, *map_get(&m, key));
-    map_remove(&m, key);
+    /* Note - calling map_remove() while iterating is not allowed! */
+    //map_remove(&m, key);
   }
 
   map_deinit(&m);

--- a/src/utils/tests/test_map.c
+++ b/src/utils/tests/test_map.c
@@ -1,0 +1,60 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "map.h"
+
+#include "minunit/minunit.h"
+
+
+typedef map_t(unsigned int) map_uint_t;
+
+
+MU_TEST(test_map)
+{
+  map_uint_t m;
+  unsigned int *p;
+  const char *key;
+  map_iter_t iter;
+
+  map_init(&m);
+  map_set(&m, "testkey", 123);
+  p = map_get(&m, "testkey");
+  mu_assert_int_eq(123, *p);
+
+  iter = map_iter(&m);
+  while ((key = map_next(&m, &iter))) {
+    printf("%s -> %u\n", key, *map_get(&m, key));
+    map_remove(&m, key);
+  }
+
+  map_deinit(&m);
+}
+
+
+MU_TEST(test_map2)
+{
+  map_str_t m;
+
+  map_init(&m);
+  char **str = map_get(&m, "no-such-key");
+  mu_check(str == NULL);
+
+  map_deinit(&m);
+}
+
+
+/***********************************************************************/
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_RUN_TEST(test_map);
+  MU_RUN_TEST(test_map2);
+}
+
+
+int main()
+{
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  return (minunit_fail) ? 1 : 0;
+}

--- a/src/utils/tests/test_plugin.c
+++ b/src/utils/tests/test_plugin.c
@@ -17,7 +17,7 @@ PluginInfo *info=NULL;
 MU_TEST(test_info_create)
 {
   char *path = STRINGIFY(BINDIR);
-  mu_check((info = plugin_info_create("TestPlugin", "get_testapi", NULL)));
+  mu_check((info = plugin_info_create("TestPlugin", "get_testapi", NULL, NULL)));
             //"TEST_PLUGIN_PATH")));
   mu_assert_int_eq(0, plugin_path_append(info, path));
 }

--- a/src/utils/tests/test_session.c
+++ b/src/utils/tests/test_session.c
@@ -1,0 +1,85 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "err.h"
+#include "session.h"
+
+#include "minunit/minunit.h"
+
+
+
+MU_TEST(test_session)
+{
+  Session *s1 = session_create("mysession");
+  Session *s2 = session_create("mysession");
+  err_clear();
+  Session *s3 = session_get("mysession");
+  Session *s4 = session_get("no-such-session");
+  const char *id = session_get_id(s1);
+  mu_check(s1);
+  mu_check(s2 == NULL);
+  mu_check(s3 == s1);
+  mu_check(s4 == NULL);
+  mu_assert_string_eq("mysession", id);
+  session_free(s1);
+  err_clear();
+}
+
+
+MU_TEST(test_default)
+{
+  int stat;
+  Session *s1 = session_get_default();
+  Session *s2 = session_get_default();
+  mu_check(s2 == s1);
+  err_clear();
+
+  stat = session_set_default(s1);
+  mu_assert_int_eq(0, stat);
+
+  Session *s3 = session_create("new-session");
+  stat = session_set_default(s3);
+  mu_assert_int_eq(1, stat);
+
+  session_free(s1);
+  session_free(s3);
+  err_clear();
+}
+
+
+MU_TEST(test_state)
+{
+  int stat;
+  Session *s = session_get_default();
+  char *data = strdup("my state data...");
+  stat = session_add_state(s, "data-id", data, free);
+  mu_assert_int_eq(0, stat);
+
+  stat = session_add_state(s, "another-id", "static state data", NULL);
+  mu_assert_int_eq(0, stat);
+
+  char *data2 = session_get_state(s, "data-id");
+  mu_assert_string_eq(data, data2);
+
+  session_free(s);
+  err_clear();
+}
+
+
+
+/***********************************************************************/
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_RUN_TEST(test_session);
+  MU_RUN_TEST(test_default);
+  MU_RUN_TEST(test_state);
+}
+
+
+int main()
+{
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  return (minunit_fail) ? 1 : 0;
+}

--- a/storages/hdf5/dh5lite.c
+++ b/storages/hdf5/dh5lite.c
@@ -828,8 +828,9 @@ static DLiteStoragePlugin h5_plugin = {
 
 
 DSL_EXPORT const DLiteStoragePlugin *
-get_dlite_storage_plugin_api(int *iter)
+get_dlite_storage_plugin_api(void *state, int *iter)
 {
   UNUSED(iter);
+  dlite_globals_set(state);
   return &h5_plugin;
 }

--- a/storages/json/dlite-json-storage.c
+++ b/storages/json/dlite-json-storage.c
@@ -288,8 +288,9 @@ static DLiteStoragePlugin dlite_json_plugin = {
 
 
 DSL_EXPORT const DLiteStoragePlugin *
-get_dlite_storage_plugin_api(int *iter)
+get_dlite_storage_plugin_api(void *state, int *iter)
 {
   UNUSED(iter);
+  dlite_globals_set(state);
   return &dlite_json_plugin;
 }

--- a/storages/python/dlite-plugins-python.c
+++ b/storages/python/dlite-plugins-python.c
@@ -261,13 +261,16 @@ int iterNext(void *iter, char *buf)
 /*
   Returns API provided by storage plugin `name` implemented in Python.
 */
-DSL_EXPORT const DLiteStoragePlugin *get_dlite_storage_plugin_api(int *iter)
+DSL_EXPORT const DLiteStoragePlugin *
+get_dlite_storage_plugin_api(void *state, int *iter)
 {
   int n;
   DLiteStoragePlugin *api=NULL, *retval=NULL;
   PyObject *storages=NULL, *cls=NULL, *name=NULL;
   PyObject *open=NULL, *close=NULL, *queue=NULL, *load=NULL, *save=NULL;
   const char *classname=NULL;
+
+  dlite_globals_set(state);
 
   if (!(storages = dlite_python_storage_load())) goto fail;
   assert(PyList_Check(storages));

--- a/storages/rdf/dlite-rdf.c
+++ b/storages/rdf/dlite-rdf.c
@@ -752,8 +752,9 @@ static DLiteStoragePlugin rdf_plugin = {
 
 
 DSL_EXPORT const DLiteStoragePlugin *
-get_dlite_storage_plugin_api(int *iter)
+get_dlite_storage_plugin_api(void *state, int *iter)
 {
   UNUSED(iter);
+  dlite_globals_set(state);
   return &rdf_plugin;
 }

--- a/tools/dlite-codegen.c
+++ b/tools/dlite-codegen.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
     case 'B':  dlite_set_use_build_root(1); break;
     case 'f':  format = optarg; break;
     case 'h':  help(stdout); exit(0);
-    case 'n':  dlite_codegen_use_native_typenames = 1; break;
+    case 'n':  dlite_codegen_set_native_typenames(1); break;
     case 'o':  output = optarg; break;
     case 's':  dlite_storage_plugin_path_append(optarg); break;
     case 'm':  dlite_instance_load_url(optarg); break;


### PR DESCRIPTION
All globals variables should now have been removed from dlite. dlite-mish implements now a globals handler that is shared with dynamically loaded plugins. This way we ensure that the plugins uses the same global state as the main program. 

Next step: when compiling the plugins, link dlite statically.
This should hopefully simplify compilation Windows.
