### PR TITLE
Statically linked dlite and dlite-utils into the plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,10 +220,15 @@ endif()
 # Python
 # ======
 if(WITH_PYTHON)
+
   if(CROSS_TARGET AND MINGW)
     set(Python3_FIND_REGISTRY NEVER)
     set(Python3_FIND_STRATEGY LOCATION)
     set(Python3_ROOT_DIR /usr/${TOOLCHAIN_PREFIX})
+  endif()
+
+  if(WIN32)
+    set(Python3_USE_STATIC_LIBS TRUE)
   endif()
 
   set(CMAKE_CROSSCOMPILING_EMULATOR ${RUNNER})

--- a/storages/hdf5/CMakeLists.txt
+++ b/storages/hdf5/CMakeLists.txt
@@ -9,8 +9,8 @@ add_definitions(-DHAVE_CONFIG_H)
 
 add_library(dlite-plugins-hdf5 SHARED ${sources})
 target_link_libraries(dlite-plugins-hdf5
-  dlite
-  dlite-utils
+  dlite-static
+  dlite-utils-static
   ${HDF5_LIBRARIES}
   )
 target_include_directories(dlite-plugins-hdf5 PUBLIC

--- a/storages/json/CMakeLists.txt
+++ b/storages/json/CMakeLists.txt
@@ -9,8 +9,8 @@ add_definitions(-DHAVE_CONFIG_H)
 
 add_library(dlite-plugins-json SHARED ${sources})
 target_link_libraries(dlite-plugins-json
-  dlite
-  dlite-utils
+  dlite-static
+  dlite-utils-static
   )
 target_include_directories(dlite-plugins-json PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/storages/python/CMakeLists.txt
+++ b/storages/python/CMakeLists.txt
@@ -9,8 +9,8 @@ set(sources
 
 add_library(dlite-plugins-python SHARED ${sources})
 target_link_libraries(dlite-plugins-python
-  dlite
-  dlite-utils
+  dlite-static
+  dlite-utils-static
   ${Python3_LIBRARIES}
   )
 target_include_directories(dlite-plugins-python PUBLIC

--- a/storages/rdf/CMakeLists.txt
+++ b/storages/rdf/CMakeLists.txt
@@ -11,8 +11,8 @@ add_library(dlite-plugins-rdf SHARED ${sources})
 target_link_libraries(dlite-plugins-rdf
   ${REDLAND_LIBRARIES}
   ${RAPTOR_LIBRARIES}
-  dlite
-  dlite-utils
+  dlite-static
+  dlite-utils-static
   )
 target_include_directories(dlite-plugins-rdf PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Should we also statically link dlite-utils into dlite? That would produce a single DLite library (both shared and static).

I guess it is preferable to not link Python and NumPy statically to allow to use dlite with different (binary compatible) versions of Python and NumPy.

