### PR TITLE
Fix failing tests when cross-compiling with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,21 @@ endif()
 # Environment for running tests in build tree
 # -------------------------------------------
 
+# Name of all targets that produce a DLL that we have to take special
+# care of on Windows
+set(dll_targets
+  dlite
+  dlite-utils
+  dlite-plugins-json
+  dlite-plugins-python
+  )
+if(WITH_HDF5)
+  list(APPEND targets dlite-plugins-python)
+endif()
+if(WITH_REDLAND)
+  list(APPEND targets dlite-plugins-rdf)
+endif()
+
 # Macro that appends build directories `dirs` to list `lst`
 #
 # Usage: build_append(<var> dirs...)
@@ -529,6 +544,19 @@ make_platform_paths(
     dlite_MAPPING_PLUGINS
   #PATHSEP0
   )
+
+# Workaround for cross-compiling for Windows on Linux using MinGW.
+# Some paths in ${dlite_PATH} may start with "Z:/" which the
+# $<SHELL_PATH:...> generator expression complains about being a
+# relative path.  To fix this, we strip off the initial "Z:".
+if(CROSS_TARGET AND MINGW)
+  set(paths "")
+  foreach(path ${dlite_PATH})
+    string(REGEX REPLACE "^[A-Z]:(/.*)" "\\1" out ${path})
+    list(APPEND paths ${out})
+  endforeach()
+  set(dlite_PATH ${paths})
+endif()
 
 set(dlite_PATH_NATIVE1 "")
 foreach(path ${dlite_PATH})

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -83,12 +83,21 @@ foreach(source ${py_sources})
   list(APPEND abs_targets ${pkgdir}/${source})
 endforeach()
 
+# On windows, also copy all dlite DLLs to our Python package
+set(dlls)
+if(WINDOWS OR MINGW)
+  foreach(dll_target ${dll_targets})
+    list(APPEND dlls $<TARGET_FILE:${dll_target}>)
+  endforeach()
+endif()
+
 add_custom_command(
   TARGET ${SWIG_MODULE_dlite_REAL_NAME}
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E make_directory ${pkgdir}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
     $<TARGET_FILE:${SWIG_MODULE_dlite_REAL_NAME}>
+    ${dlls}
     ${pkgdir}
   BYPRODUCTS
     ${pkgdir}


### PR DESCRIPTION
Added two workarounds
* Copy all DLLs to the dlite Python package in binary dir, such
  that they can be found by the Python tests.
* Strip off initial "Z:" from paths when cross-compiling with MinGW.