### PR TITLE
Python bindings to inspect dlites internal storage

### DIFF
--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -79,6 +79,15 @@ bool dlite_swig_has_instance(const char *id, bool check_storages)
   return (dlite_instance_has(id, check_storages)) ? 1 : 0;
 }
 
+/* Returns list of uuids from istore. */
+char** dlite_swig_istore_get_uuids()
+{
+  int n;
+  char** uuids;
+  uuids = dlite_istore_get_uuids(&n);
+  return uuids;
+}
+
 %}
 
 
@@ -492,6 +501,13 @@ in the storage plugin path.
 %rename(has_instance) dlite_swig_has_instance;
 bool dlite_swig_has_instance(const char *id, bool check_storages=true);
 
+
+%feature("docstring", "\
+Returns a list of in-memory stored ids.
+
+") dlite_swig_istore_get_uuids;
+%rename(istore_get_uuids) dlite_swig_istore_get_uuids;
+char** dlite_swig_istore_get_uuids();
 
 %rename(_get_property) dlite_swig_get_property;
 %rename(_set_property) dlite_swig_set_property;

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
   test_python_storage
   test_storage
   test_paths
+  test_global_dlite_state
   )
 
 foreach(test ${tests})

--- a/bindings/python/tests/global_dlite_state_mod1.py
+++ b/bindings/python/tests/global_dlite_state_mod1.py
@@ -1,0 +1,7 @@
+import importlib
+import dlite
+
+def assert_exists_in_module(uuid):
+    assert dlite.has_instance(uuid)
+    assert uuid in dlite.istore_get_uuids()
+

--- a/bindings/python/tests/global_dlite_state_mod2.py
+++ b/bindings/python/tests/global_dlite_state_mod2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import pickle
+
+import dlite
+from dlite import Instance, Dimension, Property, Relation
+
+assert len(dlite.istore_get_uuids()) == 3 + 3
+
+thisdir = os.path.abspath(os.path.dirname(__file__))
+
+url = 'json://' + thisdir + '/MyEntity.json'
+
+# myentity is already defined via test_global_dlite_state, no new instance is added to istore
+myentity = Instance(url)
+assert myentity.uri == "http://onto-ns.com/meta/0.1/MyEntity"
+assert len(dlite.istore_get_uuids()) == 3 + 3
+
+i1 = Instance(myentity.uri, [2, 3], 'myid')
+assert i1.uri == "myid"
+assert i1.uuid in dlite.istore_get_uuids()
+assert len(dlite.istore_get_uuids()) == 3 + 4
+

--- a/bindings/python/tests/global_dlite_state_mod2.py
+++ b/bindings/python/tests/global_dlite_state_mod2.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import pickle
 
 import dlite
 from dlite import Instance, Dimension, Property, Relation

--- a/bindings/python/tests/global_dlite_state_mod3.py
+++ b/bindings/python/tests/global_dlite_state_mod3.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import pickle
 
 import dlite
 

--- a/bindings/python/tests/global_dlite_state_mod3.py
+++ b/bindings/python/tests/global_dlite_state_mod3.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import pickle
+
+import dlite
+
+assert len(dlite.istore_get_uuids()) == 3 + 4
+
+coll=dlite.Collection()
+assert len(dlite.istore_get_uuids()) == 3 + 5
+
+

--- a/bindings/python/tests/global_dlite_state_mod4.py
+++ b/bindings/python/tests/global_dlite_state_mod4.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import pickle
+
+import dlite
+
+assert len(dlite.istore_get_uuids()) == 3 + 5
+
+coll=dlite.Collection()
+assert len(dlite.istore_get_uuids()) == 3 + 6
+
+

--- a/bindings/python/tests/global_dlite_state_mod4.py
+++ b/bindings/python/tests/global_dlite_state_mod4.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import pickle
 
 import dlite
 

--- a/bindings/python/tests/global_dlite_state_sub.py
+++ b/bindings/python/tests/global_dlite_state_sub.py
@@ -1,0 +1,5 @@
+import dlite
+
+def assert_exists(uuid):
+    assert dlite.has_instance(uuid)
+    assert uuid in dlite.istore_get_uuids()

--- a/bindings/python/tests/global_dlite_state_sub.py
+++ b/bindings/python/tests/global_dlite_state_sub.py
@@ -1,5 +1,0 @@
-import dlite
-
-def assert_exists(uuid):
-    assert dlite.has_instance(uuid)
-    assert uuid in dlite.istore_get_uuids()

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -38,6 +38,9 @@ assert inst.is_data
 assert not inst.is_meta
 assert not inst.is_metameta
 
+assert dlite.has_instance(inst.uuid)
+assert inst.uuid in dlite.istore_get_uuids()
+
 # Assign properties
 inst['a-blob'] = bytearray(b'0123456789abcdef')
 inst['a-blob-array'] = [[b'0123', b'4567'], [b'89ab', b'cdef']]

--- a/bindings/python/tests/test_global_dlite_state.py
+++ b/bindings/python/tests/test_global_dlite_state.py
@@ -1,27 +1,51 @@
+import os
+import importlib
 import dlite
-from global_dlite_state_sub import assert_exists
+from dlite import Instance
 
-uuids_in_istore=len(dlite.istore_get_uuids())
+from global_dlite_state_mod1 import assert_exists_in_module
 
-# When this test_global_dlite_state.py is run standalone, we have uuids_in_istore == 3 (Basic, hardcoded dlite instances,
-# since we have not added anything yet)
+thisdir = os.path.abspath(os.path.dirname(__file__))
 
-# But when this test is run as a testcase in test_python_bindings.py, this test is executed in the same Python process
-# as previous tests and those previous tests have already populated dlites internal storage (which nicely illustrates the point).
+assert len(dlite.istore_get_uuids()) == 3 # 3 Hardcoded dlite instances
 
-if uuids_in_istore in [3, 12]:
-    pass
-else:
-    msg="\n"
-    for n, uuid in enumerate(dlite.istore_get_uuids()):
-        inst=dlite.get_instance(uuid)
-        msg+=f"{n}: {uuid}, {inst.uri}\n---\n {inst}\n"
-    raise RuntimeError(msg)
-
-coll = dlite.Collection()
+coll = dlite.Collection() # (1)
 assert dlite.has_instance(coll.uuid)
-
-assert_exists(coll.uuid)
-
 assert coll.uuid in dlite.istore_get_uuids()
-assert len(dlite.istore_get_uuids()) == uuids_in_istore+1
+assert len(dlite.istore_get_uuids()) == 3 + 1
+
+# Must exist in imported dlite in different module (mod1)
+assert_exists_in_module(coll.uuid)
+
+url = 'json://' + thisdir + '/MyEntity.json' + "?mode=r"
+e = Instance(url) # (2)
+assert len(dlite.istore_get_uuids()) == 3 + 2
+
+inst1 = Instance(e.uri, [3, 2])  # (3)
+assert len(dlite.istore_get_uuids()) == 3 + 3
+
+inst2 = Instance(e.uri, (3, 4), 'myinst')  # (4)
+assert len(dlite.istore_get_uuids()) == 3 + 4
+
+del inst1
+assert len(dlite.istore_get_uuids()) == 3 + 3
+
+# Use compile and exec with dlite defined in globals
+env = globals().copy()
+filename=os.path.join(thisdir, 'global_dlite_state_mod2.py')
+
+with open(filename) as fd:
+    exec(compile(fd.read(), filename, 'exec'), env)
+
+# mod2 has added one instance
+assert len(dlite.istore_get_uuids()) == 3 + 4
+
+# Use importlib with mod3
+importlib.import_module('global_dlite_state_mod3')
+
+# mod3 has added one instance
+assert len(dlite.istore_get_uuids()) == 3 + 5
+
+importlib.__import__('global_dlite_state_mod4', globals=env, locals=None, fromlist=(), level=0)
+# mod4 has added one instance
+assert len(dlite.istore_get_uuids()) == 3 + 6

--- a/bindings/python/tests/test_global_dlite_state.py
+++ b/bindings/python/tests/test_global_dlite_state.py
@@ -1,0 +1,12 @@
+import dlite
+from global_dlite_state_sub import assert_exists
+
+uuids_in_istore=len(dlite.istore_get_uuids())
+
+coll = dlite.Collection()
+assert dlite.has_instance(coll.uuid)
+
+assert_exists(coll.uuid)
+
+assert coll.uuid in dlite.istore_get_uuids()
+assert len(dlite.istore_get_uuids()) == uuids_in_istore+1

--- a/bindings/python/tests/test_global_dlite_state.py
+++ b/bindings/python/tests/test_global_dlite_state.py
@@ -3,6 +3,14 @@ from global_dlite_state_sub import assert_exists
 
 uuids_in_istore=len(dlite.istore_get_uuids())
 
+# When this test_global_dlite_state.py is run standalone, we have uuids_in_istore == 3 (Basic, hardcoded dlite instances,
+# since we have not added anything yet)
+
+# But when this test is run as a testcase in test_python_bindings.py, this test is executed in the same Python process
+# as previous tests and those previous tests have already populated dlites internal storage (which nicely illustrates the point).
+
+assert uuids_in_istore in [3, 12]
+
 coll = dlite.Collection()
 assert dlite.has_instance(coll.uuid)
 

--- a/bindings/python/tests/test_global_dlite_state.py
+++ b/bindings/python/tests/test_global_dlite_state.py
@@ -9,7 +9,13 @@ uuids_in_istore=len(dlite.istore_get_uuids())
 # But when this test is run as a testcase in test_python_bindings.py, this test is executed in the same Python process
 # as previous tests and those previous tests have already populated dlites internal storage (which nicely illustrates the point).
 
-assert uuids_in_istore in [3, 12]
+if uuids_in_istore in [3, 12]:
+    pass
+else:
+    msg="\n"
+    for n, uuid in enumerate(dlite.istore_get_uuids()):
+        msg+=f"{n}: {uuid}\n"
+    raise RuntimeError(msg)
 
 coll = dlite.Collection()
 assert dlite.has_instance(coll.uuid)

--- a/bindings/python/tests/test_global_dlite_state.py
+++ b/bindings/python/tests/test_global_dlite_state.py
@@ -14,7 +14,8 @@ if uuids_in_istore in [3, 12]:
 else:
     msg="\n"
     for n, uuid in enumerate(dlite.istore_get_uuids()):
-        msg+=f"{n}: {uuid}\n"
+        inst=dlite.get_instance(uuid)
+        msg+=f"{n}: {uuid}, {inst.uri}\n---\n {inst}\n"
     raise RuntimeError(msg)
 
 coll = dlite.Collection()

--- a/bindings/python/tests/test_python_bindings.py
+++ b/bindings/python/tests/test_python_bindings.py
@@ -32,7 +32,7 @@ class ScriptTestCase(unittest.TestCase):
 
 
 def test(verbosity=1, stream=sys.stdout):
-    tests = [test for test in glob(os.path.join(thisdir, '*.py'))
+    tests = [test for test in sorted(glob(os.path.join(thisdir, 'test_*.py')))
              if not test.endswith('__.py') and
              not test.endswith('test_python_bindings.py')]
     ts = unittest.TestSuite()

--- a/bindings/python/tests/test_python_bindings.py
+++ b/bindings/python/tests/test_python_bindings.py
@@ -35,6 +35,8 @@ def test(verbosity=1, stream=sys.stdout):
     tests = [test for test in sorted(glob(os.path.join(thisdir, 'test_*.py')))
              if not test.endswith('__.py')
              and not test.endswith('test_python_bindings.py')
+             # Exclude test_global_dlite_state.py since the global state
+             # that it is testing depends on the other tests.
              and not test.endswith('test_global_dlite_state.py')]
     ts = unittest.TestSuite()
     for test in tests:

--- a/bindings/python/tests/test_python_bindings.py
+++ b/bindings/python/tests/test_python_bindings.py
@@ -33,8 +33,9 @@ class ScriptTestCase(unittest.TestCase):
 
 def test(verbosity=1, stream=sys.stdout):
     tests = [test for test in sorted(glob(os.path.join(thisdir, 'test_*.py')))
-             if not test.endswith('__.py') and
-             not test.endswith('test_python_bindings.py')]
+             if not test.endswith('__.py')
+             and not test.endswith('test_python_bindings.py')
+             and not test.endswith('test_global_dlite_state.py')]
     ts = unittest.TestSuite()
     for test in tests:
         ts.addTest(ScriptTestCase(filename=os.path.abspath(test)))

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -326,6 +326,34 @@ size_t dlite_instance_size(const DLiteMeta *meta, const size_t *dims)
   return size;
 }
 
+/* Return of newly allocated NULL-terminated array of string pointers
+   with uuids available in the internal storage (istore) */
+char** dlite_istore_get_uuids(int* nuuids)
+{
+    instance_map_t* istore = _instance_store();
+    assert(istore);
+    const char* uuid;
+    map_iter_t iter;
+
+    iter = map_iter(istore);
+    *nuuids = 0;
+    while ((uuid = map_next(istore, &iter))) (*nuuids)++;
+
+    char** uuids;
+    uuids = malloc((*nuuids + 1) * sizeof(char*));
+
+    int i = 0;
+    iter = map_iter(istore);
+    while ((uuid = map_next(istore, &iter))) {
+        {
+            uuids[i] = malloc(DLITE_UUID_LENGTH + 1);
+            strcpy(uuids[i], uuid);
+            i++;
+        }
+    }
+    uuids[i] = NULL;
+    return uuids;
+}
 
 /********************************************************************
  *  Instances
@@ -638,7 +666,7 @@ DLiteInstance *dlite_instance_get(const char *id)
   DLiteStoragePathIter *iter;
   const char *url;
 
-  /* check if instance `id` is already instansiated... */
+  /* check if instance `id` is already instantiated... */
   if ((inst = _instance_store_get(id))) {
     dlite_instance_incref(inst);
     return inst;

--- a/src/dlite-entity.h
+++ b/src/dlite-entity.h
@@ -416,6 +416,14 @@ void dlite_instance_debug(const DLiteInstance *inst);
  */
 size_t dlite_instance_size(const DLiteMeta *meta, const size_t *dims);
 
+/**
+  Returns a newly allocated NULL-terminated array of string pointers
+  with uuids available in the internal storage (istore).
+
+  Mostly intended for internal/debugging use.
+
+*/
+char** dlite_istore_get_uuids(int* nuuids);
 
 /** @} */
 /* ================================================================= */

--- a/storages/json/tests/test_json_storage.c
+++ b/storages/json/tests/test_json_storage.c
@@ -29,7 +29,8 @@ MU_TEST(test_get_instance_from_in_memory_store)
     char* filename = STRINGIFY(DLITE_ROOT) "/src/tests/test-data.json";
     DLiteStorage* s = NULL;
     DLiteInstance* inst1, * inst0, *stat = NULL;
-    int r;
+    int r, i;
+    char** uuids;
     printf("\n--- test_get_instance_from_in_memory_store ---\n");
 
     // Instance cannot be in store
@@ -53,6 +54,14 @@ MU_TEST(test_get_instance_from_in_memory_store)
     inst1 = dlite_instance_get(inst0->uuid);
     mu_check(inst1);
     dlite_instance_debug(inst1);
+
+    // Show all ids in istore
+    int n;
+    uuids = dlite_istore_get_uuids(&n);
+    for (i = 0; i < n; i++) {
+        printf("%d: %s\n", i, uuids[i]);
+    }
+    mu_assert_int_eq(5, n);
 }
 
 MU_TEST(test_remove_last_instance)


### PR DESCRIPTION
Adds a function to dlite-entity.c and the respective Python bindings to inspect the internal storage of dlite. Adds a Python-test.

Example from Python

```
import dlite
print(dlite.istore_get_uuids())
```

Returns a list of uuids available in the internal storage. Primarily intended for debugging/testing.