### PR TITLE
Bson plugin

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -16,10 +16,8 @@ import numpy as np
 
 class InstanceEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, bytearray):
-            return base64.b16encode(obj).decode()
-        elif isinstance(obj, bytes):
-            return obj.decode()
+        if isinstance(obj, (bytes, bytearray)):
+            return obj.hex()
         elif isinstance(obj, np.ndarray):
             if obj.dtype.kind == 'V':
                 conv = lambda e: ([conv(ele) for ele in e]

--- a/bindings/python/dlite-python.i
+++ b/bindings/python/dlite-python.i
@@ -196,22 +196,26 @@ void dlite_swig_capsula_free(PyObject *cap)
 }
 
 
+/* Read Python hexstring `hexstr` of length ``2*n``, convert it to bytes
+   and write the result to `dest`.  `n` bytes are written to `dest`.
+   Returns non-zero on error. */
 /*
-int dlite_swig_hexstring(char *dest, size_t n, PyObject str)
+int dlite_swig_read_hexstring(char *dest, size_t n, PyObject hexstr)
+{
+  PyObject *str = PyObject_Str(hexstr);
+  if (!str)
+    return dlite_err(-1, ""
+    Py_DECREF(bytes);
+    Py_DECREF(str);
+  }
+  if (PyUnicode_READY(str)) {
+    Py_DECREF(str);
+    FAIL("failed preparing string");
+  }
 
-          PyObject *str = PyObject_Str(obj);
-        if (!str) {
-          Py_DECREF(bytes);
-          Py_DECREF(str);
-        }
-        if (PyUnicode_READY(str)) {
-          Py_DECREF(str);
-          FAIL("failed preparing string");
-        }
-
-        Py_DECREF(str);
+  Py_DECREF(str);
+}
 */
-
 
 /**********************************************
  ** Python-specific implementations

--- a/bindings/python/dlite-python.i
+++ b/bindings/python/dlite-python.i
@@ -196,6 +196,22 @@ void dlite_swig_capsula_free(PyObject *cap)
 }
 
 
+/*
+int dlite_swig_hexstring(char *dest, size_t n, PyObject str)
+
+          PyObject *str = PyObject_Str(obj);
+        if (!str) {
+          Py_DECREF(bytes);
+          Py_DECREF(str);
+        }
+        if (PyUnicode_READY(str)) {
+          Py_DECREF(str);
+          FAIL("failed preparing string");
+        }
+
+        Py_DECREF(str);
+*/
+
 
 /**********************************************
  ** Python-specific implementations
@@ -378,14 +394,12 @@ int dlite_swig_set_array(void *ptr, int ndims, int *dims,
       for (i=0; i<n; i++, itemptr+=itemsize) {
         char **p = *((char ***)ptr);
         PyObject *s = PyArray_GETITEM(arr, itemptr);
-        assert(s);
-        if (!PyUnicode_Check(s))
-          FAIL("array elements should be strings");
-        if (PyUnicode_READY(s))
-          FAIL("failed preparing string");
         if (s == Py_None) {
           if (p[i]) free(p[i]);
         } else if (PyUnicode_Check(s)) {
+          assert(s);
+          if (PyUnicode_READY(s))
+            FAIL("failed preparing string");
           long len = (long)PyUnicode_GET_LENGTH(s);
           p[i] = realloc(p[i], len+1);
           memcpy(p[i], PyUnicode_1BYTE_DATA(s), len);
@@ -615,7 +629,10 @@ int dlite_swig_set_scalar(void *ptr, DLiteType type, size_t size, obj_t *obj)
     {
       size_t n;
       PyObject *bytes = PyObject_Bytes(obj);
-      if (!bytes) FAIL("cannot convert object to bytes");
+      if (!bytes) {
+        //xxx
+        FAIL("cannot convert object to bytes");
+      }
       assert(PyBytes_Check(bytes));
       n = PyBytes_Size(bytes);
       if (n > size) {

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
   test_python_storage
   test_storage
   test_paths
+  test_utils
   test_global_dlite_state
   )
 

--- a/bindings/python/tests/test_utils.py
+++ b/bindings/python/tests/test_utils.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+import os
+import json
+from pathlib import Path
+
+import dlite
+from dlite.utils import instance_from_dict
+
+
+thisdir = Path(__file__).absolute().parent
+with open(thisdir / 'Person.json', 'rt') as f:
+    d = json.load(f)
+
+Person = dlite.utils.instance_from_dict(d)
+
+person = Person([2])
+person.name = 'Ada'
+person.age = 12.5
+person.skills = ['skiing', 'jumping']
+
+d1 = person.asdict()
+inst1 = instance_from_dict(d1)
+assert inst1.uuid == person.uuid
+assert inst1.meta.uuid == Person.uuid
+assert inst1.name == 'Ada'
+assert inst1.age == 12.5
+assert all(inst1.skills == ['skiing', 'jumping'])
+
+d2 = Person.asdict()
+inst2 = instance_from_dict(d2)
+assert inst2.uuid == Person.uuid
+
+
+dlite.storage_path.append(thisdir / '*.json')
+d = {
+    "uuid": "7ee0f569-1355-4eed-a2f7-0fc31378d56c",
+    "meta": "http://onto-ns.com/meta/0.1/MyEntity",
+    "dimensions": {
+        "N": 2,
+        "M": 3
+    },
+    "properties": {
+        #"a-blob": bytes.fromhex("00112233445566778899aabbccddeeff"),
+        "a-blob": "00112233445566778899aabbccddeeff",
+        "a-blob-array": [
+            [
+                b"abcd",
+                b"efgh"
+            ],
+            [
+                b"ijkl",
+                b"mnop"
+            ]
+        ],
+        "a-bool": True,
+        "a-bool-array": [
+            False,
+            True
+        ],
+        "an-int": 42,
+        "an-int-array": [
+            -1,
+            -2,
+            -3
+        ],
+        "a-float": 3.14,
+        "a-float64-array": [
+            0.0,
+            1.6022e-19,
+            6.022e23
+        ],
+        "a-fixstring": "fix",
+        "a-fixstring-array": [
+            [
+                "one",
+                "two"
+            ],
+            [
+                "three",
+                "four"
+            ]
+        ],
+        "a-string": None,
+        "a-string-array": [
+            [
+                None,
+                "a string",
+                None
+            ],
+            [
+                None,
+                None,
+                None
+            ]
+        ],
+        "a-relation": {
+            "s": "a-subject",
+            "p": "a-predicate",
+            "o": "a-object"
+        },
+        "a-relation-array": [
+            {
+                "s": "a1",
+                "p": "b1",
+                "o": "c1"
+            },
+            {
+                "s": "a2",
+                "p": "b2",
+                "o": "c2"
+            }
+        ]
+    }
+}
+inst = instance_from_dict(d)
+print(inst)

--- a/bindings/python/tests/test_utils.py
+++ b/bindings/python/tests/test_utils.py
@@ -40,8 +40,8 @@ d = {
         "M": 3
     },
     "properties": {
-        #"a-blob": bytes.fromhex("00112233445566778899aabbccddeeff"),
-        "a-blob": "00112233445566778899aabbccddeeff",
+        "a-blob": bytes.fromhex("00112233445566778899aabbccddeeff"),
+        #"a-blob": "00112233445566778899aabbccddeeff",
         "a-blob-array": [
             [
                 b"abcd",

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -12,9 +12,14 @@ def instance_from_dict(d):
     meta = dlite.get_instance(d['meta'])
     if meta.is_metameta:
 
+        if 'uri' in d:
+            uri = d['uri']
+        else:
+            uri = d['namespace'] + '/' + d['version'] + '/' + d['name']
+
         try:
             with dlite.silent:
-                inst = dlite.get_instance(d['uri'])
+                inst = dlite.get_instance(uri)
                 if inst:
                     return inst
         except dlite.DLiteError:
@@ -23,20 +28,15 @@ def instance_from_dict(d):
         dimensions = [dlite.Dimension(d['name'], d.get('description'))
                       for d in d['dimensions']]
         props = []
-        dimmap = {dim['name']: i for i, dim in enumerate(d['dimensions'])}
         for p in d['properties']:
-            if 'dims' in p:
-                dims = [dimmap[d] for d in p['dims']]
-            else:
-                dims = None
             props.append(dlite.Property(
                 name=p['name'],
                 type=p['type'],
-                dims=dims,
+                dims=p.get('dims'),
                 unit=p.get('unit'),
                 iri=p.get('iri'),
                 description=p.get('description')))
-        inst = dlite.Instance(d['uri'], dimensions, props, d.get('iri'),
+        inst = dlite.Instance(uri, dimensions, props, d.get('iri'),
                               d.get('description'))
     else:
         dims = list(d['dimensions'].values())
@@ -48,6 +48,7 @@ def instance_from_dict(d):
 
 def get_package_paths():
     return {k:v for k,v in dlite.__dict__.items() if k.endswith('path')}
+
 
 if __name__ == '__main__':
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -126,6 +126,7 @@ requirements = [
     "PyYAML",
     "psycopg2-binary",
     "pandas",
+    "pymongo",
 ]
 
 setup_requirements = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 PyYAML
 psycopg2-binary
 pandas
+pymongo

--- a/src/utils/LICENSES.txt
+++ b/src/utils/LICENSES.txt
@@ -137,3 +137,207 @@ trivial code cleanups) would be sent back in order to let me include them in
 the version available at <http://www.jhweiss.de/software/snprintf.html>.
 However, this is not a requirement for using or redistributing (possibly
 modified) versions of this file, nor is leaving this notice intact mandatory.
+
+License for pymongo
+-------------------
+                            Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/storages/python/python-storage-plugins/README.md
+++ b/storages/python/python-storage-plugins/README.md
@@ -3,17 +3,23 @@ Python storage plugins distributed with DLite
 This directory contains additional storage plugins written in Python,
 including
 
+* blob - a plugin for Binary Large OBjects (BLOBs).
+
+* bson - a plugin for BSON (binary JSON). Consists of two files:
+  "bson_plugin.py" and "save_bson.py". Requires the pymongo package.
+
+* csv - a plugin for CSV files.
+
+* postgresql - a PostgreSQL plugin that allows to serialise all types
+  of dlite instances (including data instances, metadata, collections,
+  etc) to a PostgreSQL database.  See below for how to enable the tests.
+
 * yaml - a YAML plugin that is very similar to the json plugin
   implemented in C, except that it uses YAML instead of JSON.
 
   Including documentation, this plugin is only 72 lines of Python
   code.  Compare that to the more than 2800 codelines for the JSON
   plugin implemented in C.
-
-* postgresql - a PostgreSQL plugin that allows to serialise all types
-  of dlite instances (including data instances, metadata, collections,
-  etc) to a PostgreSQL database.  See below for how to enable the tests.
-
 
 Enabling the postgresql storage tests
 -------------------------------------

--- a/storages/python/python-storage-plugins/bson.py
+++ b/storages/python/python-storage-plugins/bson.py
@@ -1,0 +1,170 @@
+"""A DLite storage plugin for BSON written in Python."""
+import os
+import subprocess
+import sys
+
+import binascii
+from binascii import unhexlify
+import bson as pybson # Must be pymongo.bson
+
+import dlite
+from dlite.options import Options
+from dlite.utils import instance_from_dict
+
+
+class bson(DLiteStorageBase):
+    """DLite storage plugin for BSON."""
+
+    def open(self, uri, options=None):
+        """Open `uri`.
+
+        The `options` argument provies additional input to the driver.
+        Which options that are supported varies between the plugins.
+        It should be a valid URL query string of the form:
+
+            key1=value1;key2=value2...
+
+        An ampersand (&) may be used instead of the semicolon (;).
+
+        Typical options supported by most drivers include:
+        - mode : append (default) | r | w
+            Valid values are:
+            - append   Append to existing file or create new file
+            - r        Open existing file for read-only
+            - w        Truncate existing file or create new file
+
+        After the options are passed, this method may set attribute
+        `writable` to True if it is writable and to False otherwise.
+        If `writable` is not set, it is assumed to be True.
+        
+        The BSON data is translated to JSON.
+        """
+        self.options = Options(options, defaults='mode=append')
+        self.mode = dict(r='rb', w='wb', append='rb+')[self.options.mode]
+        self.writable = False if 'rb' in self.mode else True
+        self.uri = uri
+        self.d = {}
+        if self.mode in ('rb', 'rb+') and os.path.exists(uri):
+            with open(uri, self.mode) as f:
+                bson_data = f.read()
+                if pybson.is_valid(bson_data):
+                    self.d = pybson.decode(bson_data)
+                    if self.d == {}:
+                        raise EOFError("Failed to read BSON data from " + uri)
+                else:
+                    raise EOFError("Invalid BSON data in source " + uri)
+
+    def close(self):
+        """Close this storage and write the data to file.
+
+        Assumes the data to store is in JSON format.
+        """
+        if self.writable:
+            if self.mode == 'rb+' and not os.path.exists(self.uri):
+                mode = 'wb'
+            else:
+                mode = self.mode
+            esc_seq = { # Escape sequences
+                '5c30' : '00', # Null: '\\0' -> '\0' = hex 00
+                '5c61' : '07', # Bell: '\\a' -> '\a' = hex 07
+                '5c62' : '08', # Backspace: '\\b' -> '\b' = hex 08
+                '5c74' : '09', # Horizontal Tab: '\\t' -> '\t' = hex 09
+                '5c6e' : '0a', # Line Feed: '\\n' -> '\n' = hex 0a
+                '5c76' : '0b', # Vertical Tab: '\\v' -> '\v' = hex 0b
+                '5c66' : '0c', # Form Feed: '\\f' -> '\f' = hex 0c
+                '5c72' : '0d', # Carriage Return: '\\r' -> '\r' = hex 0d
+                '5c65' : '1b', # Escape: '\\e' -> '\e' = hex 1b
+                '5c5c' : '5c', # Backslash: '\\\\' -> '\\' = hex 5c
+                }
+            entries = {}
+            for uuid in self.queue():
+                d = str(self.d[uuid])
+                sp = d.split("bytearray(b'")
+                d = sp.pop(0)
+                # Convert binary strings in sp to hex strings
+                for s in sp:
+                    n = s.find("')")
+                    raws = "r'" + s[:n] + "'"
+                    # NOTE 02.12.2021:
+                    # DLite corrupts binary strings in Python, but not
+                    # raw strings, so s[:n].encode('utf-8').hex()
+                    # does not work, but 'hexs' below does
+                    hexs = raws.encode('utf-8').hex()
+                    # hexs must be '7227' + h + '27', where h is a
+                    # hexadecimal string of length divisible by two,
+                    # since each binary value maps to a two-digit
+                    # hexadecimal number.
+                    # Each pair of hexadecimal digits HH in h are
+                    # on one of the following forms:
+                    # > '5cXX' = an escape sequence in esc_seq,
+                    #            e.g. '5c6e' = b'\n'
+                    # > 'XXXX' = two binary characters,
+                    #            e.g. '3130' = b'10'
+                    # > '5c78' = the first four of eight digits
+                    #            representing one binary character
+                    #            on the form '5c78XXXX',
+                    #            e.g. '5c783130' = b'\x10'
+                    hexs = hexs.lstrip('7227') # Remove "r'"
+                    hexs = hexs.rstrip('27') # Remove "'"
+                    d = d + "'"
+                    pos = 0
+                    while pos < len(hexs):
+                        wrd = hexs[pos:(pos + 4)]
+                        pos = pos + 4
+                        if wrd[0:2] == '5c':
+                            if wrd[2:4] == '78':
+                                wrd = hexs[pos:(pos + 4)]
+                                pos = pos + 4
+                                d = d + unhexlify(wrd).decode('utf-8')
+                            else:
+                                d = d + esc_seq[wrd]
+                        else:
+                            d = d + wrd
+                    d = d + "'" + s[(n + 2):]
+                entries[uuid] = d
+            with open(self.uri, mode) as f:
+                f.write(pybson.encode(entries))
+
+    def load(self, uuid):
+        """Load `uuid` from current storage and return it
+        as a new instance.
+        """
+        for key, value in self.d.items():
+            if key == uuid:
+                if type(value) == str:
+                    value = eval(value) # Translate to dict
+                # Create instance and return it
+                meta = dlite.get_instance(value['meta'])
+                if meta.is_metameta:
+                    return instance_from_dict(value)
+                dims = list(value['dimensions'].values())
+                inst = dlite.Instance(meta.uri, dims, uuid)
+                for p in meta['properties']:
+                    if p.get_type().startswith('blob'): # Binary data
+                        data = value['properties'][p.name]
+                        try:
+                            # Test for valid binary string 'data'
+                            bin_data = bytes(data)
+                        except:
+                            # Assume hexadecimal string 'data'
+                            bin_data = bytes(binascii.unhexlify(data))
+                        inst[p.name] = bin_data
+                    else:
+                        inst[p.name] = value['properties'][p.name]
+                return inst
+        raise KeyError("Instance with id '" + uuid + "' not found")
+
+    def save(self, inst):
+        """Store `inst` in the current storage."""
+        self.d[inst.uuid] = inst.asdict()
+
+    def queue(self, pattern=None):
+        """Generator method that iterates over all UUIDs in
+        the storage who's metadata URI matches global pattern
+        `pattern`.
+        """
+        for uuid, d in self.d.items():
+            if pattern and dlite.globmatch(pattern, d['meta']):
+                continue
+            yield uuid
+

--- a/storages/python/python-storage-plugins/bson.py
+++ b/storages/python/python-storage-plugins/bson.py
@@ -1,10 +1,6 @@
 """A DLite storage plugin for BSON written in Python."""
 import os
-import subprocess
-import sys
 
-import binascii
-from binascii import unhexlify
 import bson as pybson # Must be pymongo.bson
 
 import dlite
@@ -41,18 +37,20 @@ class bson(DLiteStorageBase):
         """
         self.options = Options(options, defaults='mode=append')
         self.mode = dict(r='rb', w='wb', append='rb+')[self.options.mode]
+        if self.mode == 'rb' and not os.path.exists(uri):
+            raise FileNotFoundError(f"Did not find URI '{uri}'")
         self.writable = False if 'rb' in self.mode else True
         self.uri = uri
         self.d = {}
-        if self.mode in ('rb', 'rb+') and os.path.exists(uri):
+        if self.mode in ('rb', 'rb+'):
             with open(uri, self.mode) as f:
                 bson_data = f.read()
-                if pybson.is_valid(bson_data):
-                    self.d = pybson.decode(bson_data)
-                    if self.d == {}:
-                        raise EOFError("Failed to read BSON data from " + uri)
-                else:
-                    raise EOFError("Invalid BSON data in source " + uri)
+            if pybson.is_valid(bson_data):
+                self.d = pybson.decode(bson_data)
+                if not self.d:
+                    raise EOFError(f"Failed to read BSON data from '{uri}'")
+            else:
+                raise EOFError(f"Invalid BSON data in source '{uri}'")
 
     def close(self):
         """Close this storage and write the data to file.
@@ -64,95 +62,24 @@ class bson(DLiteStorageBase):
                 mode = 'wb'
             else:
                 mode = self.mode
-            esc_seq = { # Escape sequences
-                '5c30' : '00', # Null: '\\0' -> '\0' = hex 00
-                '5c61' : '07', # Bell: '\\a' -> '\a' = hex 07
-                '5c62' : '08', # Backspace: '\\b' -> '\b' = hex 08
-                '5c74' : '09', # Horizontal Tab: '\\t' -> '\t' = hex 09
-                '5c6e' : '0a', # Line Feed: '\\n' -> '\n' = hex 0a
-                '5c76' : '0b', # Vertical Tab: '\\v' -> '\v' = hex 0b
-                '5c66' : '0c', # Form Feed: '\\f' -> '\f' = hex 0c
-                '5c72' : '0d', # Carriage Return: '\\r' -> '\r' = hex 0d
-                '5c65' : '1b', # Escape: '\\e' -> '\e' = hex 1b
-                '5c5c' : '5c', # Backslash: '\\\\' -> '\\' = hex 5c
-                }
-            entries = {}
             for uuid in self.queue():
-                d = str(self.d[uuid])
-                sp = d.split("bytearray(b'")
-                d = sp.pop(0)
-                # Convert binary strings in sp to hex strings
-                for s in sp:
-                    n = s.find("')")
-                    raws = "r'" + s[:n] + "'"
-                    # NOTE 02.12.2021:
-                    # DLite corrupts binary strings in Python, but not
-                    # raw strings, so s[:n].encode('utf-8').hex()
-                    # does not work, but 'hexs' below does
-                    hexs = raws.encode('utf-8').hex()
-                    # hexs must be '7227' + h + '27', where h is a
-                    # hexadecimal string of length divisible by two,
-                    # since each binary value maps to a two-digit
-                    # hexadecimal number.
-                    # Each pair of hexadecimal digits HH in h are
-                    # on one of the following forms:
-                    # > '5cXX' = an escape sequence in esc_seq,
-                    #            e.g. '5c6e' = b'\n'
-                    # > 'XXXX' = two binary characters,
-                    #            e.g. '3130' = b'10'
-                    # > '5c78' = the first four of eight digits
-                    #            representing one binary character
-                    #            on the form '5c78XXXX',
-                    #            e.g. '5c783130' = b'\x10'
-                    hexs = hexs.lstrip('7227') # Remove "r'"
-                    hexs = hexs.rstrip('27') # Remove "'"
-                    d = d + "'"
-                    pos = 0
-                    while pos < len(hexs):
-                        wrd = hexs[pos:(pos + 4)]
-                        pos = pos + 4
-                        if wrd[0:2] == '5c':
-                            if wrd[2:4] == '78':
-                                wrd = hexs[pos:(pos + 4)]
-                                pos = pos + 4
-                                d = d + unhexlify(wrd).decode('utf-8')
-                            else:
-                                d = d + esc_seq[wrd]
-                        else:
-                            d = d + wrd
-                    d = d + "'" + s[(n + 2):]
-                entries[uuid] = d
+                props = self.d[uuid]['properties']
+                if type(props) == dict: # Metadata props is list
+                    for key in props.keys():
+                        if type(props[key]) in (bytearray, bytes):
+                            props[key] = props[key].hex()
+                    self.d[uuid]['properties'] = props
             with open(self.uri, mode) as f:
-                f.write(pybson.encode(entries))
+                f.write(pybson.encode(self.d))
 
     def load(self, uuid):
         """Load `uuid` from current storage and return it
         as a new instance.
         """
-        for key, value in self.d.items():
-            if key == uuid:
-                if type(value) == str:
-                    value = eval(value) # Translate to dict
-                # Create instance and return it
-                meta = dlite.get_instance(value['meta'])
-                if meta.is_metameta:
-                    return instance_from_dict(value)
-                dims = list(value['dimensions'].values())
-                inst = dlite.Instance(meta.uri, dims, uuid)
-                for p in meta['properties']:
-                    if p.get_type().startswith('blob'): # Binary data
-                        data = value['properties'][p.name]
-                        try:
-                            # Test for valid binary string 'data'
-                            bin_data = bytes(data)
-                        except:
-                            # Assume hexadecimal string 'data'
-                            bin_data = bytes(binascii.unhexlify(data))
-                        inst[p.name] = bin_data
-                    else:
-                        inst[p.name] = value['properties'][p.name]
-                return inst
-        raise KeyError("Instance with id '" + uuid + "' not found")
+        if uuid in self.d.keys():
+            return instance_from_dict(self.d[uuid])
+        else:
+            raise KeyError(f"Instance with id '{uuid}' not found")
 
     def save(self, inst):
         """Store `inst` in the current storage."""

--- a/storages/python/tests/CMakeLists.txt
+++ b/storages/python/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 set(tests
   test_yaml_storage
   test_blob_storage
+  test_bson_storage
   test_postgresql_storage
   test_postgresql_storage2
   )
@@ -34,6 +35,15 @@ if(NOT PY_YAML)
     COMMAND ${CMAKE_COMMAND} -E echo "disabled")
   set_property(TEST test_yaml_storage PROPERTY DISABLED True)
   list(REMOVE_ITEM tests test_yaml_storage)
+endif()
+
+# Disable BSON test if pymongo is not installed
+find_python_module(pymongo)
+if(NOT PY_PYMONGO)
+  add_test(NAME test_bson_storage
+    COMMAND ${CMAKE_COMMAND} -E echo "disabled")
+  set_property(TEST test_bson_storage PROPERTY DISABLED True)
+  list(REMOVE_ITEM tests test_bson_storage)
 endif()
 
 # Disable postgresql tests if psycopg2 is not installed or if pgconf.h

--- a/storages/python/tests/test_bson_storage.c
+++ b/storages/python/tests/test_bson_storage.c
@@ -1,0 +1,110 @@
+#include "minunit/minunit.h"
+
+#include "dlite.h"
+#include "dlite-macros.h"
+#include "dlite-storage-plugins.h"
+
+MU_TEST(test_save)
+{
+  DLiteStorage* s = NULL;
+
+  // Load JSON metadata
+  char* url = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
+  DLiteInstance* meta = (DLiteInstance*)dlite_meta_load_url(url);
+  mu_check(meta);
+  mu_check(dlite_instance_is_meta(meta));
+
+  // Save JSON metadata to BSON file
+  mu_check(s = dlite_storage_open("bson", "test_meta.bson", "mode=w"));
+  mu_assert_int_eq(1, dlite_storage_is_writable(s));
+  mu_assert_int_eq(0, dlite_instance_save(s, meta));
+  mu_assert_int_eq(0, dlite_storage_close(s));
+  
+  // Load JSON data (corresponding to the metadata above)
+  url = STRINGIFY(DLITE_ROOT) "/src/tests/test-data.json";
+  mu_check(s = dlite_storage_open("json", url, "mode=r"));
+  DLiteInstance* data1 = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
+  mu_check(dlite_instance_is_data(data1));
+  DLiteInstance* data2 = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
+  mu_check(dlite_instance_is_data(data2));
+  
+  // Save JSON data to BSON file
+  mu_check(s = dlite_storage_open("bson", "test_data.bson", "mode=w"));
+  mu_assert_int_eq(1, dlite_storage_is_writable(s));
+  mu_assert_int_eq(0, dlite_instance_save(s, data1));
+  mu_assert_int_eq(0, dlite_instance_save(s, data2));
+  mu_assert_int_eq(0, dlite_storage_close(s));
+  while (dlite_instance_decref(data1)); // Remove all references to data1
+  while (dlite_instance_decref(data2)); // Remove all references to data2
+  while (dlite_instance_decref(meta)); // Remove all references to meta
+}
+
+MU_TEST(test_load)
+{
+  DLiteStorage* s = NULL;
+
+  // Load JSON metadata
+  char* url = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
+  DLiteInstance* json_meta = (DLiteInstance*)dlite_meta_load_url(url);
+  char* json_str1 = dlite_json_aprint(json_meta, 0, 1);
+  while (dlite_instance_decref(json_meta)); // Remove all references to json_meta
+
+  // Load BSON metadata
+  mu_check(s = dlite_storage_open("bson", "test_meta.bson", "mode=r"));
+  DLiteInstance* bson_meta = dlite_instance_load(s, "2b10c236-eb00-541a-901c-046c202e52fa");
+  mu_check(bson_meta);
+  char* bson_str1 = dlite_json_aprint(bson_meta, 0, 1);
+  while (dlite_instance_decref(bson_meta)); // Remove all references to bson_meta
+
+  // Compare JSON and BSON metadata
+  mu_assert_int_eq(0, strcmp(json_str1, bson_str1));
+  mu_assert_int_eq(0, dlite_storage_close(s));
+  
+  // Load JSON data (corresponding to the metadata above)
+  url = STRINGIFY(DLITE_ROOT) "/src/tests/test-data.json";
+  s = dlite_storage_open("json", url, "mode=r");
+  DLiteInstance* json_data = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
+  json_str1 = dlite_json_aprint(json_data, 0, 1);
+  while (dlite_instance_decref(json_data)); // Remove all references to json_data
+  json_data = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
+  char* json_str2 = dlite_json_aprint(json_data, 0, 1);
+  while (dlite_instance_decref(json_data)); // Remove all references to json_data
+
+  // Load BSON data
+  mu_check(s = dlite_storage_open("bson", "test_data.bson", "mode=r"));
+  DLiteInstance* bson_data = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
+  mu_check(bson_data);
+  bson_str1 = dlite_json_aprint(bson_data, 0, 1);
+  while (dlite_instance_decref(bson_data)); // Remove all references to bson_data
+  bson_data = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
+  mu_check(bson_data);
+  char* bson_str2 = dlite_json_aprint(bson_data, 0, 1);
+  while (dlite_instance_decref(bson_data)); // Remove all references to bson_data
+
+  // Compare JSON and BSON data
+  mu_assert_int_eq(0, strcmp(json_str1, bson_str1));
+  mu_assert_int_eq(0, strncmp(json_str2, bson_str2, 47));
+  mu_assert_int_eq(0, strcmp(strstr(json_str2, "\"meta\""), strstr(bson_str2, "\"meta\"")));
+  mu_assert_int_eq(0, dlite_storage_close(s));
+}
+
+MU_TEST(test_unload_plugins)
+{
+  dlite_storage_plugin_unload_all();
+}
+
+/***********************************************************************/
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_RUN_TEST(test_save);
+  MU_RUN_TEST(test_load);
+  MU_RUN_TEST(test_unload_plugins);
+}
+
+int main()
+{
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  return (minunit_fail ? 1 : 0);
+}

--- a/storages/python/tests/test_bson_storage.c
+++ b/storages/python/tests/test_bson_storage.c
@@ -9,7 +9,8 @@ MU_TEST(test_save)
   DLiteStorage* s = NULL;
 
   // Load JSON metadata
-  char* url = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
+  char* url
+	  = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
   DLiteInstance* meta = (DLiteInstance*)dlite_meta_load_url(url);
   mu_check(meta);
   mu_check(dlite_instance_is_meta(meta));
@@ -23,9 +24,11 @@ MU_TEST(test_save)
   // Load JSON data (corresponding to the metadata above)
   url = STRINGIFY(DLITE_ROOT) "/src/tests/test-data.json";
   mu_check(s = dlite_storage_open("json", url, "mode=r"));
-  DLiteInstance* data1 = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
+  DLiteInstance* data1
+	  = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
   mu_check(dlite_instance_is_data(data1));
-  DLiteInstance* data2 = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
+  DLiteInstance* data2
+	  = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
   mu_check(dlite_instance_is_data(data2));
   
   // Save JSON data to BSON file
@@ -44,17 +47,19 @@ MU_TEST(test_load)
   DLiteStorage* s = NULL;
 
   // Load JSON metadata
-  char* url = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
+  char* url
+	  = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
   DLiteInstance* json_meta = (DLiteInstance*)dlite_meta_load_url(url);
   char* json_str1 = dlite_json_aprint(json_meta, 0, 1);
-  while (dlite_instance_decref(json_meta)); // Remove all references to json_meta
+  while (dlite_instance_decref(json_meta)); // Remove all json_meta references
 
   // Load BSON metadata
   mu_check(s = dlite_storage_open("bson", "test_meta.bson", "mode=r"));
-  DLiteInstance* bson_meta = dlite_instance_load(s, "2b10c236-eb00-541a-901c-046c202e52fa");
+  DLiteInstance* bson_meta
+	  = dlite_instance_load(s, "2b10c236-eb00-541a-901c-046c202e52fa");
   mu_check(bson_meta);
   char* bson_str1 = dlite_json_aprint(bson_meta, 0, 1);
-  while (dlite_instance_decref(bson_meta)); // Remove all references to bson_meta
+  while (dlite_instance_decref(bson_meta)); // Remove all bson_meta references
 
   // Compare JSON and BSON metadata
   mu_assert_int_eq(0, strcmp(json_str1, bson_str1));
@@ -63,28 +68,29 @@ MU_TEST(test_load)
   // Load JSON data (corresponding to the metadata above)
   url = STRINGIFY(DLITE_ROOT) "/src/tests/test-data.json";
   s = dlite_storage_open("json", url, "mode=r");
-  DLiteInstance* json_data = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
+  DLiteInstance* json_data
+	  = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
   json_str1 = dlite_json_aprint(json_data, 0, 1);
-  while (dlite_instance_decref(json_data)); // Remove all references to json_data
+  while (dlite_instance_decref(json_data)); // Remove all json_data references
   json_data = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
   char* json_str2 = dlite_json_aprint(json_data, 0, 1);
-  while (dlite_instance_decref(json_data)); // Remove all references to json_data
+  while (dlite_instance_decref(json_data)); // Remove all json_data references
 
   // Load BSON data
   mu_check(s = dlite_storage_open("bson", "test_data.bson", "mode=r"));
-  DLiteInstance* bson_data = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
+  DLiteInstance* bson_data
+	  = dlite_instance_load(s, "204b05b2-4c89-43f4-93db-fd1cb70f54ef");
   mu_check(bson_data);
   bson_str1 = dlite_json_aprint(bson_data, 0, 1);
-  while (dlite_instance_decref(bson_data)); // Remove all references to bson_data
+  while (dlite_instance_decref(bson_data)); // Remove all bson_data references
   bson_data = dlite_instance_load(s, "e076a856-e36e-5335-967e-2f2fd153c17d");
   mu_check(bson_data);
   char* bson_str2 = dlite_json_aprint(bson_data, 0, 1);
-  while (dlite_instance_decref(bson_data)); // Remove all references to bson_data
+  while (dlite_instance_decref(bson_data)); // Remove all bson_data references
 
   // Compare JSON and BSON data
   mu_assert_int_eq(0, strcmp(json_str1, bson_str1));
-  mu_assert_int_eq(0, strncmp(json_str2, bson_str2, 47));
-  mu_assert_int_eq(0, strcmp(strstr(json_str2, "\"meta\""), strstr(bson_str2, "\"meta\"")));
+  mu_assert_int_eq(0, strcmp(json_str2, bson_str2));
   mu_assert_int_eq(0, dlite_storage_close(s));
 }
 
@@ -93,7 +99,7 @@ MU_TEST(test_unload_plugins)
   dlite_storage_plugin_unload_all();
 }
 
-/***********************************************************************/
+/****************************************************************************/
 
 MU_TEST_SUITE(test_suite)
 {


### PR DESCRIPTION
Add BSON plugin for DLite

DLite seems to currently mess up binary strings, by replacing '\\' with '\\\\', which messes up control sequences (e.g. '\n' (hex '0a') becomes '\\\\n', which is interpreted as '\\\\' and 'n' (i.e hex '5c6e')). The plugin is therefore written as a workaround. If this issue can be resolved, the plugin Python code can probably be simplified.

The plugin has only been tested for BSON files generated by itself (by pymongo), not for BSON files generated by other sources.

EDIT: The problem mentioned above has been fixed, so the plugin has been simplified.