### PR TITLE
Added support for skipping python tests if they exit with return code 44

### DIFF
--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
   test_paths
   test_utils
   test_global_dlite_state
+  test_property_mappings
   )
 
 foreach(test ${tests})
@@ -31,5 +32,8 @@ foreach(test ${tests})
   endif()
   set_property(TEST ${name} APPEND PROPERTY
     ENVIRONMENT "DLITE_USE_BUILD_ROOT=YES")
+
+  # Skip tests that exit with return code 44
+  set_property(TEST ${name} PROPERTY SKIP_RETURN_CODE 44)
 
 endforeach()

--- a/bindings/python/tests/test_property_mappings.py
+++ b/bindings/python/tests/test_property_mappings.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+from pathlib import Path
+
+import dlite
+import dlite.mappings as dm
+
+try:
+    import pintaaa
+except ImportError as exc:
+    import sys
+    print(f"Skipped: {exc}")
+    sys.exit(44)  # exit code marking the test to be skipped
+
+
+# Configure search paths
+thisdir = Path(__file__).parent.absolute()
+dlite.storage_path.append(f'{thisdir}/*.json')
+
+
+mappings = [
+    ('http://onto-ns.com/meta/0.1/Molecule#name', ':mapsTo',
+     'chem:Identifier'),
+    ('http://onto-ns.com/meta/0.1/Molecule#groundstate_energy', ':mapsTo',
+     'chem:GroundStateEnergy'),
+    ('http://onto-ns.com/meta/0.1/Substance#id', ':mapsTo',
+     'chem:Identifier'),
+    ('http://onto-ns.com/meta/0.1/Substance#molecule_energy', ':mapsTo',
+     'chem:GroundStateEnergy'),
+]
+
+
+match = dm.match_factory(mappings)
+match_first = dm.match_factory(mappings, match_first=True)
+
+
+
+
+# Check unitconvert_pint
+assert dm.unitconvert_pint("km", 34, 'm') == 0.034
+assert dm.unitconvert_pint("Å", 34, 'um') == 34e4
+assert dm.unitconvert_pint("s", 1, 'hour') == 3600
+
+
+routes = dm.mapping_route(
+    target='http://onto-ns.com/meta/0.1/Substance#molecule_energy',
+    sources=['http://onto-ns.com/meta/0.1/Molecule#groundstate_energy'],
+    triples=mappings)

--- a/bindings/python/tests/test_python_bindings.py
+++ b/bindings/python/tests/test_python_bindings.py
@@ -19,7 +19,13 @@ class ScriptTestCase(unittest.TestCase):
         env = globals().copy()
         env.update(__file__=self.filename)
         with open(self.filename) as fd:
-            exec(compile(fd.read(), self.filename, 'exec'), env)
+            try:
+                exec(compile(fd.read(), self.filename, 'exec'), env)
+            except SystemExit as exc:
+                if exc.code == 44:
+                    self.skipTest('exit code 44')
+                else:
+                    raise exc
 
     def id(self):
         return self.filename


### PR DESCRIPTION
Can be used to skip tests that depends on a module that is not available