### PR TITLE
Make workflow3 run in dehydrogenation example.

### DIFF
--- a/examples/dehydrogenation/3-property-mappings/mappings_from_ontology/map_molecules.py
+++ b/examples/dehydrogenation/3-property-mappings/mappings_from_ontology/map_molecules.py
@@ -13,13 +13,13 @@ rootdir = thisdir.parent.parent
 world = World()
 
 mapsTo_onto = world.get_ontology(f'{rootdir}/ontology/mapsTo.ttl').load(
-    EMMObased=False)
+    emmo_based=False)
 
 chemistry_onto = world.get_ontology(f'{rootdir}/ontology/chemistry.ttl').load()
 
 dlite_onto = world.get_ontology('https://raw.githubusercontent.com/'
                           'emmo-repo/datamodel-ontology/master'
-                          '/dlitemodel.ttl').load(EMMObased=False)
+                          '/dlitemodel.ttl').load(emmo_based=False)
 mapping = world.get_ontology('http://onto-ns.com/ontology/mapping#')
 mapping.set_version('0.1')
 mapping.imported_ontologies.extend([mapsTo_onto, chemistry_onto, dlite_onto])

--- a/examples/dehydrogenation/3-property-mappings/mappings_from_ontology/map_substance.py
+++ b/examples/dehydrogenation/3-property-mappings/mappings_from_ontology/map_substance.py
@@ -11,13 +11,13 @@ rootdir = thisdir.parent.parent
 world = World()
 
 mapsTo_onto = world.get_ontology(f'{rootdir}/ontology/mapsTo.ttl').load(
-    EMMObased=False)
+    emmo_based=False)
 
 chemistry_onto = world.get_ontology(f'{rootdir}/ontology/chemistry.ttl').load()
 
 dlite_onto = world.get_ontology(
     'https://raw.githubusercontent.com/emmo-repo/datamodel-ontology/master'
-    '/dlitemodel.ttl').load(EMMObased=False)
+    '/dlitemodel.ttl').load(emmo_based=False)
 
 mapping = world.get_ontology('http://onto-ns.com/ontology/mapping#')
 mapping.set_version('0.1')

--- a/examples/dehydrogenation/README.md
+++ b/examples/dehydrogenation/README.md
@@ -112,7 +112,7 @@ In the second step these mappings are read into the run script and combined into
 Mapping between data form the external repository and Bobs desired Substance(s) is then done automatically because of the common ontology.
 
 Discussion on choice of ontology is not part of this dlite example, but Bob could also have used another ontology and match to something else and thus
-also have access to other data repos mapped to other ontologies.
+also have access to other data repos mapped to other ontologies. Note also that in the mapsTo.ttl  ontology _mapsTo_ is defined as an _owl:AnnotationProperty_. A more semantic description would be to make it an _rdf:Property_ . However, both Protégé (one of the preferred ontology work softwares) and Owlready2 (which EMMOntoPy builds upon) are based on owl, and this will lead to problems with the interpreters. 
 
     python 3-property-mappings/mappings_from_ontology/run_w_onto.py
 

--- a/examples/dehydrogenation/ontology/mapsTo.ttl
+++ b/examples/dehydrogenation/ontology/mapsTo.ttl
@@ -9,7 +9,7 @@
 <http://onto-ns.com/ontology/mapsTo> rdf:type owl:Ontology ;
     owl:versionIRI <http://onto-ns.com/ontology/0.1/mapsTo> .
 
-:mapsTo rdf:type rdf:Property ;
+:mapsTo rdf:type owl:AnnotationProperty ;
     rdfs:subPropertyOf rdfs:subClassOf ;
     rdfs:comment "Maps a resource (represented as a class in the ontology) to a concept (represented as another class) in an ontology."@en ;
     rdfs:label "mapsTo"@en ;

--- a/examples/dehydrogenation/ontology/ontology.py
+++ b/examples/dehydrogenation/ontology/ontology.py
@@ -1,7 +1,7 @@
 # from ontopy import get_ontology # will soon release on pypi the bigg
 # structure change in emmo-python
 
-from emmo import get_ontology
+from ontopy import get_ontology
 import dlite
 
 dlite.storage_path.append(f'../molecules/*.json')


### PR DESCRIPTION
Changed mapsTo from rdf:Property to owl:AnnotationProperty.

Protege and Owlready2 (and therefore also EMMOntoPy) are based on owl as
base ontology and they change the ontology when loading the original
mapsTo. This is not very practical. We therefore changed the ontology
instead of updating EMMOntoPy. This might be changed in the future.
Commented in the README.md.

Note that we have also made mapsTo an rdfs:subPropertyOf rdfs:SubClassOf. This adds semantic meaning, but is not used for anything right now.