### PR TITLE
Cleanup keyword arguments

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -6,6 +6,7 @@ set(py_sources
   options.py
   utils.py
   mappings.py
+  datamodel.py
   )
 
 configure_file(paths.py.in paths.py)

--- a/bindings/python/datamodel.py
+++ b/bindings/python/datamodel.py
@@ -1,0 +1,122 @@
+"""Module that simplifies creating a data model."""
+import ast
+import warnings
+
+import dlite
+from dlite.utils import instance_from_dict
+
+
+class DataModelError(dlite.DLiteError):
+    """Raised if the datamodel is inconsistent."""
+
+class MissingDimensionError(DataModelError):
+    """Raised if a dimension referred to in a property is not defined."""
+
+class UnusedDimensionError(DataModelError):
+    """Raised if a dimension is not referred to in any property."""
+
+
+class DataModel:
+    """Class for creating a data model."""
+
+    def __init__(self, uri, schema=None, description=None):
+        """Initialise
+
+        Parameters:
+            uri: URI identifying the data model.
+            schema: URI of the metadata for the data model.  Defaults to
+              EntitySchema.
+            description: Human description of the data model.
+        """
+        self.uri = uri
+        self._set_schema(schema)
+        self.description = description
+        self.dimensions = {}
+        self.properties = {}
+        self.relations = []
+
+    schema = property(
+        lambda self: self._schema,
+        lambda self, schema: self._set_schema(schema),
+        doc='Meta-metadata for the datamodel.',
+    )
+
+    def _set_schema(self, schema):
+        if not schema:
+            self._schema = dlite.get_instance(dlite.ENTITY_SCHEMA)
+        elif isinstance(schema, dlite.Instance):
+            self._schema = schema
+        elif isinstance(schema, str):
+            self._schema = dlite.get_instance(schema)
+        else:
+            TypeError('`schema` must be a string or a DLite metadata schema.')
+
+    def add_dimension(self, name, description):
+        """Add dimension with given `name` and description to data model."""
+        if name in self.dimensions:
+            raise KeyError(f'A dimension named "{name}" already exists')
+        self.dimensions[name] = dlite.Dimension(name, description)
+
+    def add_property(self, name, type, dims=None, unit=None, description=None):
+        """Add property to data model.
+
+        Parameters:
+            name: Property label.
+            type: Property type.
+            dims: Shape of Property.  Default is scalar.
+            unit: Unit. Default is dimensionless.
+            description: Human description.
+        """
+        if name in self.properties:
+            raise KeyError(f'A property named "{name}" already exists')
+        self.properties[name] = dlite.Property(
+            name=name,
+            type=type,
+            dims=dims,
+            unit=unit,
+            description=description,
+        )
+
+    def _get_dims_variables(self):
+        """Returns a set of all dimension names referred to in property dims."""
+        names = set()
+        for prop in self.properties.values():
+            if prop.dims is not None:
+                for dim in prop.dims:
+                    tree = ast.parse(dim)
+                    names.update(node.id for node in ast.walk(tree)
+                                 if isinstance(node, ast.Name))
+        return names
+
+    def get_missing_dimensions(self):
+        """Returns a set of dimension names referred to in property shapes but
+        is not in dimensions.
+        """
+        return self._get_dims_variables().difference(self.dimensions)
+
+    def get_unused_dimensions(self):
+        """Returns a set of dimensions not referred to in any property shapes."""
+        return set(self.dimensions).difference(self._get_dims_variables())
+
+    def validate(self):
+        """Raises an exception if there are missing or unused dimensions."""
+        missing = self.get_missing_dimensions()
+        if missing:
+            raise MissingDimensionError(f'Missing dimensions: {missing}')
+        unused = self.get_unused_dimensions()
+        if unused:
+            raise UnusedDimensionError(f'Unused dimensions: {unused}')
+
+    def get(self):
+        """Returns a DLite Metadata created from the datamodel."""
+        self.validate()
+        dims = [len(self.dimensions), len(self.properties)]
+        if 'nrelations' in self.schema:
+            dims.append(len(self.relations))
+        meta = self.schema(dims, id=self.uri)
+        meta.description = self.description
+        meta['dimensions'] = list(self.dimensions.values())
+        meta['properties'] = list(self.properties.values())
+        if 'relations' in meta:
+            meta['relations'] = self.relations
+        return meta

--- a/bindings/python/dlite-collection-python.i
+++ b/bindings/python/dlite-collection-python.i
@@ -44,6 +44,14 @@
 
     meta = property(get_meta, doc='Reference to metadata of this collection.')
 
+    @classmethod
+    def create_from_storage(cls, storage, id=None, lazy=True):
+        return cls(storage=storage, id=id, lazy=lazy)
+
+    @classmethod
+    def create_from_url(cls, url, id=None, lazy=True):
+        return cls(url=url, id=id, lazy=lazy)
+
     def asdict(self):
         """Returns a dict representation of self."""
         return self.asinstance().asdict()

--- a/bindings/python/dlite-collection-python.i
+++ b/bindings/python/dlite-collection-python.i
@@ -45,6 +45,10 @@
     meta = property(get_meta, doc='Reference to metadata of this collection.')
 
     @classmethod
+    def create(cls, id=None, lazy=True):
+        return cls(id=id, lazy=lazy)
+
+    @classmethod
     def create_from_storage(cls, storage, id=None, lazy=True):
         return cls(storage=storage, id=id, lazy=lazy)
 

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -247,7 +247,9 @@ def standardise(v, asdict=True):
                    )
 
     def __getitem__(self, ind):
-        if self.has_property(ind):
+        if isinstance(ind, int):
+            return self.get_property_by_index(ind)
+        elif self.has_property(ind):
             return self.get_property(ind)
         elif isinstance(ind, int):
             raise IndexError('instance property index out of range: %d' % ind)
@@ -255,7 +257,9 @@ def standardise(v, asdict=True):
             raise KeyError('no such property: %s' % ind)
 
     def __setitem__(self, ind, value):
-        if self.has_property(ind):
+        if isinstance(ind, int):
+            self.set_property_by_index(ind, value)
+        elif self.has_property(ind):
             self.set_property(ind, value)
         elif isinstance(ind, int):
             raise IndexError('instance property index out of range: %d' % ind)

--- a/bindings/python/dlite-storage-python.i
+++ b/bindings/python/dlite-storage-python.i
@@ -18,6 +18,12 @@
       def __iter__(self):
           return StorageIterator(self)
 
+      @classmethod
+      def create_from_url(cls, url):
+          """Create a new storage from `url`."""
+          return cls(url)
+
+
       def instances(self, pattern=None):
           """Returns an iterator over all instances in storage whos
           metadata URI matches `pattern`."""
@@ -33,7 +39,7 @@
 
       def save(self, inst):
           """Stores instance `inst` in this storage."""
-          inst.save(self)
+          inst.save(storage=self)
 
       driver = property(get_driver,
                         doc='Name of driver associated with this storage')

--- a/bindings/python/dlite-storage.i
+++ b/bindings/python/dlite-storage.i
@@ -66,18 +66,16 @@ enum _DLiteIDFlag {
 %feature("docstring", "\
 Represents a data storage.
 
-Call signatures
----------------
-Storage(driver, location, options)
-Storage(url)
-
 Parameters
 ----------
-driver : string
-    Name of driver used to connect to the storage.
+driver_or_url : string
+    Name of driver used to connect to the storage or, if `location` is not
+    given, the URL to the storage:
+
+        driver://location?options
+
 location : string
     The location to the storage.  For file storages, this is the file name.
-    For web-based storages this is the location-part of the url.
 options : string
     Additional options passed to the driver as a list of semicolon-separated
     ``key=value`` pairs.  Each driver may have their own options.  Some
@@ -86,10 +84,6 @@ options : string
         create a new one (hdf5,json).
       - compact={'yes','no'}: Whether to store in a compact format (json).
       - meta={'yes','no'}: Whether to format output as metadata (json).
-url : string
-    A combination of `driver`, `location` and `options` in the form
-
-        driver://location?options
 ") _DLiteStorage;
 %rename(Storage) _DLiteStorage;
 
@@ -102,12 +96,12 @@ struct _DLiteStorage {
 };
 
 %extend _DLiteStorage {
-  %feature("docstring", "") __init__;
-  _DLiteStorage(const char *driver, const char *location, const char *options) {
-    return dlite_storage_open(driver, location, options);
-  }
-  _DLiteStorage(const char *url) {
-    return dlite_storage_open_url(url);
+  _DLiteStorage(const char *driver_or_url, const char *location=NULL,
+                const char *options=NULL) {
+    if (!location)
+      return dlite_storage_open_url(driver_or_url);
+    else
+      return dlite_storage_open(driver_or_url, location, options);
   }
   ~_DLiteStorage(void) {
     dlite_storage_close($self);

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
   test_utils
   test_global_dlite_state
   test_property_mappings
+  test_datamodel
   )
 
 foreach(test ${tests})

--- a/bindings/python/tests/test_datamodel.py
+++ b/bindings/python/tests/test_datamodel.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from pathlib import Path
+
+import dlite
+from dlite.datamodel import DataModel
+
+
+datamodel = DataModel('http://onto-ns/meta/0.1/Atoms')
+datamodel.description = 'A test entity for atoms...'
+datamodel.add_dimension('natoms', 'Number of atoms.')
+datamodel.add_dimension('ncoords', 'Number of coordinates (always 3).')
+datamodel.add_dimension('nvecs', 'Number of lattice vectors (always 3).')
+datamodel.add_property('symbol', 'string', ['natoms'],
+                       description='Chemical symbol of each atom.')
+datamodel.add_property('positions', 'float', ['natoms', 'ncoords'],
+                       description='Position of each atom.')
+datamodel.add_property('unitcell', 'float', ['nvecs', 'ncoords'],
+                       description='Unit cell.')
+Atoms = datamodel.get()

--- a/bindings/python/tests/test_python_storage.py
+++ b/bindings/python/tests/test_python_storage.py
@@ -58,7 +58,6 @@ del uuids
 
 input_dir = thisdir.replace('bindings', 'storages')
 input_dir = input_dir.replace('tests', 'tests-python/input/')
-print('*** input_dir:', input_dir)
 
 if HAVE_BSON:
     # Test BSON

--- a/bindings/python/tests/test_python_storage.py
+++ b/bindings/python/tests/test_python_storage.py
@@ -17,7 +17,7 @@ else:
     HAVE_YAML = True
 
 
-thisdir = os.path.dirname(__file__)
+thisdir = os.path.abspath(os.path.dirname(__file__))
 
 # Test JSON
 
@@ -58,6 +58,7 @@ del uuids
 
 input_dir = thisdir.replace('bindings', 'storages')
 input_dir = input_dir.replace('tests', 'tests-python/input/')
+print('*** input_dir:', input_dir)
 
 if HAVE_BSON:
     # Test BSON

--- a/examples/dehydrogenation/1-simple-workflow/calculate_reaction.py
+++ b/examples/dehydrogenation/1-simple-workflow/calculate_reaction.py
@@ -19,7 +19,7 @@ products = {'C2H4': 1, 'H2': 1}
 
 coll = dlite.Collection(f'json://{atomdata}?mode=r#molecules', 0)
 
-Reaction = dlite.Instance(f'json://{entitydir}/Reaction.json')
+Reaction = dlite.Instance.create_from_url(f'json://{entitydir}/Reaction.json')
 
 reaction = Reaction(dims=[len(reactants), len(products)])
 

--- a/examples/dehydrogenation/1-simple-workflow/calculate_reaction.py
+++ b/examples/dehydrogenation/1-simple-workflow/calculate_reaction.py
@@ -17,7 +17,7 @@ dlite.python_mapping_plugin_path.append(f'{mappingdir}')
 reactants = {'C2H6': 1}
 products = {'C2H4': 1, 'H2': 1}
 
-coll = dlite.Collection(f'json://{atomdata}?mode=r#molecules', 0)
+coll = dlite.Collection.create_from_url(f'json://{atomdata}?mode=r#molecules')
 
 Reaction = dlite.Instance.create_from_url(f'json://{entitydir}/Reaction.json')
 

--- a/examples/dehydrogenation/1-simple-workflow/molecular_energies.py
+++ b/examples/dehydrogenation/1-simple-workflow/molecular_energies.py
@@ -35,7 +35,7 @@ Molecule = dlite.Instance.create_from_url(f'json://{entitydir}/Molecule.json')
 
 
 # Create a new collection and populate it with all molecule structures
-coll = dlite.Collection('molecules')
+coll = dlite.Collection(id='molecules')
 for filename in moldir.glob('*.xyz'):
     molname = filename.stem
     mol = readMolecule(filename)

--- a/examples/dehydrogenation/1-simple-workflow/molecular_energies.py
+++ b/examples/dehydrogenation/1-simple-workflow/molecular_energies.py
@@ -31,7 +31,8 @@ def readMolecule(filename):
     return inst
 
 
-Molecule = dlite.Instance(f'json://{entitydir}/Molecule.json')  # DLite Metadata
+Molecule = dlite.Instance.create_from_url(f'json://{entitydir}/Molecule.json')
+
 
 # Create a new collection and populate it with all molecule structures
 coll = dlite.Collection('molecules')

--- a/examples/dehydrogenation/2-instance-mappings/calculate_reactions.py
+++ b/examples/dehydrogenation/2-instance-mappings/calculate_reactions.py
@@ -14,7 +14,7 @@ dlite.python_mapping_plugin_path.append(f'{rootdir}/python-mapping-plugins')
 
 
 # Load collection with atom scale data
-coll = dlite.Collection(f'json://{atomdata}?mode=r#molecules', 0)
+coll = dlite.Collection.create_from_url(f'json://{atomdata}?mode=r#molecules')
 
 # Define the reaction of interest and calculate the reaction energy
 r = reaction_energy.reaction_energy(coll, reactants={'C2H6': 1},

--- a/examples/dehydrogenation/3-property-mappings/mappings_from_ontology/run_w_onto.py
+++ b/examples/dehydrogenation/3-property-mappings/mappings_from_ontology/run_w_onto.py
@@ -61,7 +61,7 @@ mapsTo = molecules_onto.mapsTo.iri
 
 # Define where the molecule data is obtained from
 # This is a dlite collection
-coll = dlite.Collection(f'json://{atomdata}?mode=r#molecules', 0)
+coll = dlite.Collection.create_from_url(f'json://{atomdata}?mode=r#molecules')
 
 
 # input from chemical engineer, e.g. what are reactants and products

--- a/examples/dehydrogenation/3-property-mappings/mappings_hard_coded/run.py
+++ b/examples/dehydrogenation/3-property-mappings/mappings_hard_coded/run.py
@@ -51,7 +51,7 @@ def get_energy(reaction):
 
 # Define where the molecule data is obtained from
 # This is a dlite collection
-coll = dlite.Collection(f'json://{atomdata}?mode=r#molecules', 0)
+coll = dlite.Collection.create_from_url(f'json://{atomdata}?mode=r#molecules')
 
 # input from chemical engineer, e.g. what are reactants and products
 # reactants (left side of equation) have negative stochiometric coefficient

--- a/examples/dehydrogenation/README.md
+++ b/examples/dehydrogenation/README.md
@@ -112,7 +112,7 @@ In the second step these mappings are read into the run script and combined into
 Mapping between data form the external repository and Bobs desired Substance(s) is then done automatically because of the common ontology.
 
 Discussion on choice of ontology is not part of this dlite example, but Bob could also have used another ontology and match to something else and thus
-also have access to other data repos mapped to other ontologies. Note also that in the mapsTo.ttl  ontology _mapsTo_ is defined as an _owl:AnnotationProperty_. A more semantic description would be to make it an _rdf:Property_ . However, both Protégé (one of the preferred ontology work softwares) and Owlready2 (which EMMOntoPy builds upon) are based on owl, and this will lead to problems with the interpreters. 
+also have access to other data repos mapped to other ontologies. Note also that in the mapsTo.ttl  ontology _mapsTo_ is defined as an _owl:AnnotationProperty_. A more semantic description would be to make it an _rdf:Property_ . However, both Protégé (one of the preferred ontology work softwares) and Owlready2 (which EMMOntoPy builds upon) are based on owl, and this will lead to problems with the interpreters.
 
     python 3-property-mappings/mappings_from_ontology/run_w_onto.py
 
@@ -121,8 +121,6 @@ also have access to other data repos mapped to other ontologies. Note also that 
 ## Workflow 4: Ontologically described transformations
 
 TODO: write up
-- use OTEAPI
-- ProMo(?)
 
 
 ![Workflow 4](figs/dehydrogenation-workflow4.png)

--- a/examples/dehydrogenation/main.py
+++ b/examples/dehydrogenation/main.py
@@ -33,10 +33,10 @@ if HAVE_ASE:
     # Commented out for now - there are some issues in relation with
     # EMMOntoPy that will be fixed in a separate issue...
     #
-    #if HAVE_ONTOPY:
-    #    run('3-property-mappings/mappings_from_ontology/run_w_onto.py')
-    #else:
-    #    print("** warning: 'ontopy' is required for running dehydrogenisation "
-    #          "workflow 3")
+    if HAVE_ONTOPY:
+        run('3-property-mappings/mappings_from_ontology/run_w_onto.py')
+    else:
+        print("** warning: 'ontopy' is required for running dehydrogenisation "
+              "workflow 3")
 else:
     print("** warning: 'ase' is required for running dehydrogenisation example")

--- a/examples/dehydrogenation/python-mapping-plugins/molecule2substance.py
+++ b/examples/dehydrogenation/python-mapping-plugins/molecule2substance.py
@@ -9,7 +9,7 @@ class Molecule2Substance(DLiteMappingBase):
 
     def map(self, instances):
         molecule = instances[0]
-        substance = dlite.Instance(self.output_uri, [])
+        substance = dlite.Instance.create_from_metaid(self.output_uri, [])
         substance.id = molecule.name
         substance.molecule_energy = molecule.groundstate_energy
         return substance


### PR DESCRIPTION
Keyword arguments cannot be combined with function overloading, hence all function overloading have been removed. This leads to some incompatibilities compared to earlier versions. 

This PR follows up on #202 

All changes in the API are summarised below:

    # Changes to Instance 
    dlite.Instance(...)  # Updated prototype (PR #202). Use the dedicated constructors below:
    dlite.Instance.create_from_metaid(metaid, dims, id=None)  # new (PR #202)
    dlite.Instance.create_from_url(url, metaid=None)  # new (PR #202)
    dlite.Instance.create_from_storage(storage, dims, id=None, metaid=None)  # new (PR #202)
    dlite.Instance.create_from_location(driver, location, options=None, id=None)  # new (PR #202)
    dlite.Instance.create_metadata(uri, dimensions, properties, description)  # new (PR #202)

    dlite.Instance.get_dimension_size(name)  # changed: name must be a string
    dlite.Instance.get_dimension_size_by_index(index)  # new

    dlite.Instance.get_property(name)  # changed: name must be a string
    dlite.Instance.get_property_by_index(index)  # new

    dlite.Instance.has_property(name)  # changed: name must be a string
    dlite.Instance.has_property_by_index(index)  # new


    # Changes to Collection
    dlite.Collection(url=None, storage=None, id=None, lazy=False)  # Updated prototype. Use the constructors below:
    ​dlite.Collection.create(id=None, lazy=False)  # new
    dlite.Collection.create_from_url(url, id=None, lazy=False)  # new
    dlite.Collection.create_from_storage(storage, id=None, lazy=False)  # new

    dlite.Collection.save(driver_or_url, location=None, options=None)  # Updated prototype
    dlite.Collection.save_to_url(url)  # new
    dlite.Collection.save_to_storage(storage)  # new

    dlite.Collection.add_relation_triple(triple)  # new


    # Changes to Storage
    dlite.Storage(driver_or_url, location=None, options=None)  # Updated prototype
    dlite.Storage.create_from_url(url)  # new