### PR TITLE
Fix weekly image builds

### DIFF
--- a/.github/workflows/container_builds_weekly.yml
+++ b/.github/workflows/container_builds_weekly.yml
@@ -1,16 +1,15 @@
 name: Weekly wheel build images
 
 on:
-  # schedule:
-  #   - cron: "42 5 * * 1"
-  # workflow_dispatch:
-  #   inputs:
-  #     use_cache:
-  #       description: Use GH Actions cache
-  #       type: boolean
-  #       required: false
-  #       default: true
-  pull_request:
+  schedule:
+    - cron: "42 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      use_cache:
+        description: Use GH Actions cache
+        type: boolean
+        required: false
+        default: true
 
 env:
   container_registry: ghcr.io
@@ -24,18 +23,18 @@ jobs:
       matrix:
         include:
         # 64-bit linux
-        # - system: "manylinux"
-        #   type: "2010"
-        #   arch: "x86_64"
-        #   py_minors: "7 8 9"
+        - system: "manylinux"
+          type: "2010"
+          arch: "x86_64"
+          py_minors: "7 8 9"
         - system: "manylinux"
           type: "2014"
           arch: "x86_64"
           py_minors: "7 8 9 10"
-        # - system: "musllinux"
-        #   type: "_1_1"
-        #   arch: "x86_64"
-        #   py_minors: "7 8 9 10"
+        - system: "musllinux"
+          type: "_1_1"
+          arch: "x86_64"
+          py_minors: "7 8 9 10"
 
         # 32-bit linux
         - system: "manylinux"
@@ -44,14 +43,14 @@ jobs:
           py_minors: "7 8 9"
         # Doesn't seem to be working.
         # Will keep in here though, to check if it should start working.
-        # - system: "manylinux"
-        #   type: "2014"
-        #   arch: "i686"
-        #   py_minors: "7 8 9"
-        # - system: "musllinux"
-        #   type: "_1_1"
-        #   arch: "i686"
-        #   py_minors: "7 8 9 10"
+        - system: "manylinux"
+          type: "2014"
+          arch: "i686"
+          py_minors: "7 8 9"
+        - system: "musllinux"
+          type: "_1_1"
+          arch: "i686"
+          py_minors: "7 8 9 10"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/container_builds_weekly.yml
+++ b/.github/workflows/container_builds_weekly.yml
@@ -38,10 +38,10 @@ jobs:
         #   py_minors: "7 8 9 10"
 
         # 32-bit linux
-        # - system: "manylinux"
-        #   type: "2010"
-        #   arch: "i686"
-        #   py_minors: "7 8 9"
+        - system: "manylinux"
+          type: "2010"
+          arch: "i686"
+          py_minors: "7 8 9"
         # Doesn't seem to be working.
         # Will keep in here though, to check if it should start working.
         # - system: "manylinux"

--- a/.github/workflows/container_builds_weekly.yml
+++ b/.github/workflows/container_builds_weekly.yml
@@ -70,11 +70,12 @@ jobs:
       - name: Check 'latest' parent image SHA
         run: |
           IMAGE=quay.io/pypa/${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}:latest
+          SHA_FILENAME=${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}:latest.sha.txt
           docker pull ${IMAGE}
-          docker images --no-trunc --quiet ${IMAGE} > ${IMAGE}.sha.txt
+          docker images --no-trunc --quiet ${IMAGE} > ${SHA_FILENAME}
 
           CACHE_DIR=.buildx-cache-${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}
-          if [ -f "${CACHE_DIR}/${IMAGE}.sha.txt" ] && [ "$( cat ${IMAGE}.sha.txt )" == "$( cat ${CACHE_DIR}/${IMAGE}.sha.txt )" ]; then
+          if [ -f "${CACHE_DIR}/${SHA_FILENAME}" ] && [ "$( cat ${SHA_FILENAME} )" == "$( cat ${CACHE_DIR}/${SHA_FILENAME} )" ]; then
             echo "BUILD_NEW_IMAGE=false" >> $GITHUB_ENV
           else
             echo "BUILD_NEW_IMAGE=true" >> $GITHUB_ENV
@@ -123,4 +124,4 @@ jobs:
 
       - name: Add sha.txt to cache
         if: env.BUILD_NEW_IMAGE == 'true'
-        run: mv ${IMAGE}.sha.txt .buildx-cache-${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}
+        run: mv ${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}:latest.sha.txt .buildx-cache-${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}

--- a/.github/workflows/container_builds_weekly.yml
+++ b/.github/workflows/container_builds_weekly.yml
@@ -1,15 +1,16 @@
 name: Weekly wheel build images
 
 on:
-  schedule:
-    - cron: "42 5 * * 1"
-  workflow_dispatch:
-    inputs:
-      use_cache:
-        description: Use GH Actions cache
-        type: boolean
-        required: false
-        default: true
+  # schedule:
+  #   - cron: "42 5 * * 1"
+  # workflow_dispatch:
+  #   inputs:
+  #     use_cache:
+  #       description: Use GH Actions cache
+  #       type: boolean
+  #       required: false
+  #       default: true
+  pull_request:
 
 env:
   container_registry: ghcr.io
@@ -23,34 +24,34 @@ jobs:
       matrix:
         include:
         # 64-bit linux
-        - system: "manylinux"
-          type: "2010"
-          arch: "x86_64"
-          py_minors: "7 8 9"
+        # - system: "manylinux"
+        #   type: "2010"
+        #   arch: "x86_64"
+        #   py_minors: "7 8 9"
         - system: "manylinux"
           type: "2014"
           arch: "x86_64"
           py_minors: "7 8 9 10"
-        - system: "musllinux"
-          type: "_1_1"
-          arch: "x86_64"
-          py_minors: "7 8 9 10"
+        # - system: "musllinux"
+        #   type: "_1_1"
+        #   arch: "x86_64"
+        #   py_minors: "7 8 9 10"
 
         # 32-bit linux
-        - system: "manylinux"
-          type: "2010"
-          arch: "i686"
-          py_minors: "7 8 9"
+        # - system: "manylinux"
+        #   type: "2010"
+        #   arch: "i686"
+        #   py_minors: "7 8 9"
         # Doesn't seem to be working.
         # Will keep in here though, to check if it should start working.
-        - system: "manylinux"
-          type: "2014"
-          arch: "i686"
-          py_minors: "7 8 9"
-        - system: "musllinux"
-          type: "_1_1"
-          arch: "i686"
-          py_minors: "7 8 9 10"
+        # - system: "manylinux"
+        #   type: "2014"
+        #   arch: "i686"
+        #   py_minors: "7 8 9"
+        # - system: "musllinux"
+        #   type: "_1_1"
+        #   arch: "i686"
+        #   py_minors: "7 8 9 10"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fixes #232 

Fix forward slashes (`/`) in the filename for the cached sha.txt file.
Also, fix the usage of an unset variable in the last step.