### PR TITLE
Fix deploying on Windows

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -136,19 +136,23 @@ jobs:
     # Change the version in CMakeList.txt and build wheels
     # Use a Python script to be OS-independent.
     - name: Update version
-      run: |
-        import os
-        from pathlib import Path
-        import re
+      # run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION 1.2.3|" CMakeLists.txt
+      shell: bash
+      # run: |
+      #   import os
+      #   from pathlib import Path
+      #   import re
 
-        version_file = Path("CMakeLists.txt").resolve()
-        version = os.getenv("GITHUB_REF")[len("refs/tags/v"):]
-        lines = [
-            re.sub(r"^ +VERSION +[0-9.]+$", f"  VERSION {version}", line.rstrip())
-            for line in version_file.read_text(encoding="utf8").splitlines()
-        ]
-        version_file.write_text("\n".join(lines) + "\n", encoding="utf8")
-      shell: python
+      #   version_file = Path("CMakeLists.txt").resolve()
+      #   # version = os.getenv("GITHUB_REF")[len("refs/tags/v"):]
+      #   version = "1.2.3"
+      #   lines = [
+      #       re.sub(r"^ +VERSION +[0-9.]+$", f"  VERSION {version}", line.rstrip())
+      #       for line in version_file.read_text(encoding="utf8").splitlines()
+      #   ]
+      #   version_file.write_text("\n".join(lines) + "\n", encoding="utf8")
+      # shell: python
 
     - name: Set up Python 3
       uses: actions/setup-python@v2
@@ -202,7 +206,8 @@ jobs:
     # this seems like the most low-tech solution (instead of caching/using artifacts):
     # Change the version in CMakeList.txt and build wheels
     - name: Update version
-      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+      # run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION 1.2.3|" CMakeLists.txt
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -70,7 +70,7 @@ jobs:
   build_wheels:
     name: Build wheels
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +178,7 @@ jobs:
   build_sdist:
     name: Build sdist
     runs-on: ubuntu-latest
-    if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -1,10 +1,9 @@
 name: CD - Publish a new release
 
 on:
-  # release:
-  #   types:
-  #   - published
-  pull_request:
+  release:
+    types:
+    - published
 
 env:
   PUBLISH_UPDATE_BRANCH: master
@@ -13,92 +12,92 @@ env:
   CONTAINER_REGISTRY: ghcr.io
 
 jobs:
-  # update_version:
-  #   name: Update DLite version and release body
-  #   runs-on: ubuntu-latest
-  #   if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
+  update_version:
+    name: Update DLite version and release body
+    runs-on: ubuntu-latest
+    if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@v2
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-  #   - name: Set up git user
-  #     run: |
-  #       git config --global user.name "${GIT_USER_NAME}"
-  #       git config --global user.email "${GIT_USER_EMAIL}"
+    - name: Set up git user
+      run: |
+        git config --global user.name "${GIT_USER_NAME}"
+        git config --global user.email "${GIT_USER_EMAIL}"
 
-  #   - name: Update version and tag
-  #     run: |
-  #       sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+    - name: Update version and tag
+      run: |
+        sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
 
-  #       git add CMakeLists.txt
-  #       git commit -m "Release ${GITHUB_REF#refs/tags/}"
+        git add CMakeLists.txt
+        git commit -m "Release ${GITHUB_REF#refs/tags/}"
 
-  #       TAG_MSG=.github/utils/release_tag_msg.txt
-  #       sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|" "${TAG_MSG}"
-  #       git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+        TAG_MSG=.github/utils/release_tag_msg.txt
+        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|" "${TAG_MSG}"
+        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
 
-  #   - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
-  #     uses: CasperWA/push-protected@v2
-  #     with:
-  #       token: ${{ secrets.RELEASE_PAT }}
-  #       branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-  #       sleep: 15
-  #       force: true
-  #       tags: true
-  #       unprotect_reviews: true
+    - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
+      uses: CasperWA/push-protected@v2
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        sleep: 15
+        force: true
+        tags: true
+        unprotect_reviews: true
 
-  #   - name: Get tagged versions
-  #     run: echo "PREVIOUS_VERSION=$(git tag -l --sort -version:refname | sed -n 2p)" >> $GITHUB_ENV
+    - name: Get tagged versions
+      run: echo "PREVIOUS_VERSION=$(git tag -l --sort -version:refname | sed -n 2p)" >> $GITHUB_ENV
 
-  #   - name: Create release-specific changelog
-  #     uses: CharMixer/auto-changelog-action@v1
-  #     with:
-  #       token: ${{ secrets.GITHUB_TOKEN }}
-  #       release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-  #       since_tag: "${{ env.PREVIOUS_VERSION }}"
-  #       output: "release_changelog.md"
+    - name: Create release-specific changelog
+      uses: CharMixer/auto-changelog-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        since_tag: "${{ env.PREVIOUS_VERSION }}"
+        output: "release_changelog.md"
 
-  #   - name: Append changelog to release body
-  #     run: |
-  #       gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
-  #       cat release_changelog.md >> release_body.md
-  #       gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Append changelog to release body
+      run: |
+        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
+        cat release_changelog.md >> release_body.md
+        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_wheels:
     name: Build wheels
     runs-on: ${{ matrix.os }}
-    # if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
         include:
           # 32-bit linux
-          # - os: ubuntu-20.04
-          #   system_type: ["manylinux", "2010"]
-          #   arch: i686
-          #   py_minors: 7,8,9
-          # ## Doesn't seem to be working - cannot build container image for this
-          # # - os: ubuntu-20.04
-          # #   system_type: ["manylinux", "2014"]
-          # #   arch: i686
-          # #   py_minors: 7,8,9
-          # - os: ubuntu-20.04
-          #   system_type: ["musllinux", "_1_1"]
-          #   arch: i686
-          #   py_minors: 7,8,9,10
-
-          # # 64-bit linux
-          # - os: ubuntu-20.04
-          #   system_type: ["manylinux", "2010"]
-          #   arch: x86_64
-          #   py_minors: 7,8,9
+          - os: ubuntu-20.04
+            system_type: ["manylinux", "2010"]
+            arch: i686
+            py_minors: 7,8,9
+          ## Doesn't seem to be working - cannot build container image for this
           # - os: ubuntu-20.04
           #   system_type: ["manylinux", "2014"]
-          #   arch: x86_64
-          #   py_minors: 7,8,9,10
+          #   arch: i686
+          #   py_minors: 7,8,9
+          - os: ubuntu-20.04
+            system_type: ["musllinux", "_1_1"]
+            arch: i686
+            py_minors: 7,8,9,10
+
+          # 64-bit linux
+          - os: ubuntu-20.04
+            system_type: ["manylinux", "2010"]
+            arch: x86_64
+            py_minors: 7,8,9
+          - os: ubuntu-20.04
+            system_type: ["manylinux", "2014"]
+            arch: x86_64
+            py_minors: 7,8,9,10
           # See issue #225: https://github.com/SINTEF/dlite/issues/225
           # - os: ubuntu-20.04
           #   system_type: ["musllinux", "_1_1"]
@@ -134,25 +133,9 @@ jobs:
     # And to avoid checking out `master` (should someone push in-between all this),
     # this seems like the most low-tech solution (instead of caching/using artifacts):
     # Change the version in CMakeList.txt and build wheels
-    # Use a Python script to be OS-independent.
     - name: Update version
-      # run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
-      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION 1.2.3|" CMakeLists.txt
-      shell: bash
-      # run: |
-      #   import os
-      #   from pathlib import Path
-      #   import re
-
-      #   version_file = Path("CMakeLists.txt").resolve()
-      #   # version = os.getenv("GITHUB_REF")[len("refs/tags/v"):]
-      #   version = "1.2.3"
-      #   lines = [
-      #       re.sub(r"^ +VERSION +[0-9.]+$", f"  VERSION {version}", line.rstrip())
-      #       for line in version_file.read_text(encoding="utf8").splitlines()
-      #   ]
-      #   version_file.write_text("\n".join(lines) + "\n", encoding="utf8")
-      # shell: python
+      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+      shell: bash  # Enforce bash shell to make `sed` work also on Windows
 
     - name: Set up Python 3
       uses: actions/setup-python@v2
@@ -194,7 +177,7 @@ jobs:
   build_sdist:
     name: Build sdist
     runs-on: ubuntu-latest
-    # if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Checkout repository
@@ -206,8 +189,7 @@ jobs:
     # this seems like the most low-tech solution (instead of caching/using artifacts):
     # Change the version in CMakeList.txt and build wheels
     - name: Update version
-      # run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
-      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION 1.2.3|" CMakeLists.txt
+      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
@@ -257,8 +239,8 @@ jobs:
     #     user: __token__
     #     password: ${{ secrets.TEST_PYPI_TOKEN }}
 
-    # - name: Publish package to PyPI
-    #   uses: pypa/gh-action-pypi-publish@v1.5.0
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_TOKEN }}
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.5.0
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -134,9 +134,21 @@ jobs:
     # And to avoid checking out `master` (should someone push in-between all this),
     # this seems like the most low-tech solution (instead of caching/using artifacts):
     # Change the version in CMakeList.txt and build wheels
+    # Use a Python script to be OS-independent.
     - name: Update version
-      run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
-      shell: bash  # Should also work on Windows
+      run: |
+        import os
+        from pathlib import Path
+        import re
+
+        version_file = Path("CMakeLists.txt").resolve()
+        version = os.getenv("GITHUB_REF")[len("refs/tags/v"):]
+        lines = [
+            re.sub(r"^ +VERSION +[0-9.]+$", f"  VERSION {version}", line.rstrip())
+            for line in version_file.read_text(encoding="utf8").splitlines()
+        ]
+        version_file.write_text("\n".join(lines) + "\n", encoding="utf8")
+      shell: python
 
     - name: Set up Python 3
       uses: actions/setup-python@v2

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -134,6 +134,7 @@ jobs:
     # Change the version in CMakeList.txt and build wheels
     - name: Update version
       run: sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+      shell: bash  # Should also work on Windows
 
     - name: Set up Python 3
       uses: actions/setup-python@v2

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -1,9 +1,11 @@
 name: CD - Publish a new release
 
 on:
-  release:
-    types:
-    - published
+  # release:
+  #   types:
+  #   - published
+  pull_request:
+
 env:
   PUBLISH_UPDATE_BRANCH: master
   GIT_USER_NAME: "TEAM 4.0[bot]"
@@ -11,59 +13,59 @@ env:
   CONTAINER_REGISTRY: ghcr.io
 
 jobs:
-  update_version:
-    name: Update DLite version and release body
-    runs-on: ubuntu-latest
-    if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
+  # update_version:
+  #   name: Update DLite version and release body
+  #   runs-on: ubuntu-latest
+  #   if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v2
 
-    - name: Set up git user
-      run: |
-        git config --global user.name "${GIT_USER_NAME}"
-        git config --global user.email "${GIT_USER_EMAIL}"
+  #   - name: Set up git user
+  #     run: |
+  #       git config --global user.name "${GIT_USER_NAME}"
+  #       git config --global user.email "${GIT_USER_EMAIL}"
 
-    - name: Update version and tag
-      run: |
-        sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
+  #   - name: Update version and tag
+  #     run: |
+  #       sed -i -E -e "s|^ +VERSION +[0-9.]+$|  VERSION ${GITHUB_REF#refs/tags/v}|" CMakeLists.txt
 
-        git add CMakeLists.txt
-        git commit -m "Release ${GITHUB_REF#refs/tags/}"
+  #       git add CMakeLists.txt
+  #       git commit -m "Release ${GITHUB_REF#refs/tags/}"
 
-        TAG_MSG=.github/utils/release_tag_msg.txt
-        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|" "${TAG_MSG}"
-        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+  #       TAG_MSG=.github/utils/release_tag_msg.txt
+  #       sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|" "${TAG_MSG}"
+  #       git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
 
-    - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
-      uses: CasperWA/push-protected@v2
-      with:
-        token: ${{ secrets.RELEASE_PAT }}
-        branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        sleep: 15
-        force: true
-        tags: true
-        unprotect_reviews: true
+  #   - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
+  #     uses: CasperWA/push-protected@v2
+  #     with:
+  #       token: ${{ secrets.RELEASE_PAT }}
+  #       branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+  #       sleep: 15
+  #       force: true
+  #       tags: true
+  #       unprotect_reviews: true
 
-    - name: Get tagged versions
-      run: echo "PREVIOUS_VERSION=$(git tag -l --sort -version:refname | sed -n 2p)" >> $GITHUB_ENV
+  #   - name: Get tagged versions
+  #     run: echo "PREVIOUS_VERSION=$(git tag -l --sort -version:refname | sed -n 2p)" >> $GITHUB_ENV
 
-    - name: Create release-specific changelog
-      uses: CharMixer/auto-changelog-action@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        since_tag: "${{ env.PREVIOUS_VERSION }}"
-        output: "release_changelog.md"
+  #   - name: Create release-specific changelog
+  #     uses: CharMixer/auto-changelog-action@v1
+  #     with:
+  #       token: ${{ secrets.GITHUB_TOKEN }}
+  #       release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+  #       since_tag: "${{ env.PREVIOUS_VERSION }}"
+  #       output: "release_changelog.md"
 
-    - name: Append changelog to release body
-      run: |
-        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
-        cat release_changelog.md >> release_body.md
-        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: Append changelog to release body
+  #     run: |
+  #       gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
+  #       cat release_changelog.md >> release_body.md
+  #       gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_wheels:
     name: Build wheels
@@ -74,29 +76,29 @@ jobs:
       matrix:
         include:
           # 32-bit linux
-          - os: ubuntu-20.04
-            system_type: ["manylinux", "2010"]
-            arch: i686
-            py_minors: 7,8,9
-          ## Doesn't seem to be working - cannot build container image for this
           # - os: ubuntu-20.04
-          #   system_type: ["manylinux", "2014"]
+          #   system_type: ["manylinux", "2010"]
           #   arch: i686
           #   py_minors: 7,8,9
-          - os: ubuntu-20.04
-            system_type: ["musllinux", "_1_1"]
-            arch: i686
-            py_minors: 7,8,9,10
+          # ## Doesn't seem to be working - cannot build container image for this
+          # # - os: ubuntu-20.04
+          # #   system_type: ["manylinux", "2014"]
+          # #   arch: i686
+          # #   py_minors: 7,8,9
+          # - os: ubuntu-20.04
+          #   system_type: ["musllinux", "_1_1"]
+          #   arch: i686
+          #   py_minors: 7,8,9,10
 
-          # 64-bit linux
-          - os: ubuntu-20.04
-            system_type: ["manylinux", "2010"]
-            arch: x86_64
-            py_minors: 7,8,9
-          - os: ubuntu-20.04
-            system_type: ["manylinux", "2014"]
-            arch: x86_64
-            py_minors: 7,8,9,10
+          # # 64-bit linux
+          # - os: ubuntu-20.04
+          #   system_type: ["manylinux", "2010"]
+          #   arch: x86_64
+          #   py_minors: 7,8,9
+          # - os: ubuntu-20.04
+          #   system_type: ["manylinux", "2014"]
+          #   arch: x86_64
+          #   py_minors: 7,8,9,10
           # See issue #225: https://github.com/SINTEF/dlite/issues/225
           # - os: ubuntu-20.04
           #   system_type: ["musllinux", "_1_1"]
@@ -238,8 +240,8 @@ jobs:
     #     user: __token__
     #     password: ${{ secrets.TEST_PYPI_TOKEN }}
 
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.0
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+    # - name: Publish package to PyPI
+    #   uses: pypa/gh-action-pypi-publish@v1.5.0
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Fixes #234 

The issue is the use of `sed` in general (meaning, no matter the OS).
This fix enforces the use of a bash shell, which should also work on Windows through Git for Windows.