### PR TITLE
Added option `force` to replace an existing instance in a collection.

### DIFF
--- a/bindings/python/dlite-collection-python.i
+++ b/bindings/python/dlite-collection-python.i
@@ -146,8 +146,12 @@ class Collection(Instance):
     def __contains__(self, label):
         return self.has(label)
 
-    def add(self, label, inst):
-        """Add `inst` to collection with given label."""
+    def add(self, label, inst, force=False):
+        """Add `inst` to collection with given label.
+        If `force` is true, a possible existing instance will be replaced.
+        """
+        if force and self.has(label):
+            self.remove(label)
         _collection_add(self._coll, label, inst)
 
     def remove(self, label):

--- a/bindings/python/tests/test_collection.py
+++ b/bindings/python/tests/test_collection.py
@@ -80,9 +80,15 @@ inst1b = coll.get('inst1')
 assert inst1b == inst1
 assert inst1b != inst2
 
+# Cannot add an instance with an existing label
+try:
+    coll.add('inst1', inst2)
+except dlite.DLiteError:
+    pass
+else:
+    raise RuntimeError('should not be able to replace an existing instance')
 
-#
-
+coll.add('inst1', inst2, force=True)  # forced replacement
 
 s = str(coll)
 print(coll)


### PR DESCRIPTION
close #223 

It is already an error in the C api (and therefore also from Python without `force`) to add an instance with an existing label.
