### PR TITLE
Virtual environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,9 +242,8 @@ if(WITH_PYTHON)
     set(Python3_USE_STATIC_LIBS TRUE)
   endif()
 
+  # Find Python package
   set(CMAKE_CROSSCOMPILING_EMULATOR ${RUNNER})
-
-  # The
   #find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
   find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
   find_package(NumPy REQUIRED)
@@ -600,7 +599,7 @@ if(CROSS_TARGET AND MINGW)
 endif()
 
 
-set(dlite_PATH_NATIVE1 "")
+set(dlite_PATH_NATIVE1 "${CMAKE_INSTALL_PREFIX}/bin")
 foreach(path ${dlite_PATH})
   list(APPEND dlite_PATH_NATIVE1 $<SHELL_PATH:${path}>)
 endforeach()

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ able to build and install dlite via the python/setup.py script:
 Install dependencies (e.g. with `apt-get install` on Ubuntu or `dnf install` on
 Fedora)
 
-Configure the with:
+Configure the build with:
 
     mkdir build
     cd build

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Content
         - [Build dependencies](#build-dependencies)
       - [Build and install with Python](#build-and-install-with-python)
       - [Build on Linux](#build-on-linux)
-      - [Build on Windows](#build-on-windows)
+      - [Build with VS Code on Windows](#build-with-vs-code-on-windows)
         - [Quick start with VS Code and Remote Container](#quick-start-with-vs-code-and-remote-container)
       - [Build documentation](#build-documentation)
     - [Setting up the environment](#setting-up-the-environment)
@@ -308,32 +308,36 @@ able to build and install dlite via the python/setup.py script:
 
 
 ### Build on Linux
-Install the hdf5 (does not include the parallel component) libraries
+Install dependencies (e.g. with `apt-get install` on Ubuntu or `dnf install` on
+Fedora)
 
-On Ubuntu:
-
-    sudo apt-get install libhdf5-serial-dev
-
-On Redhad-based distributions (Fedora, Centos, ...):
-
-    sudo dnf install hdf5-devel
-
-Build with:
+Configure the with:
 
     mkdir build
     cd build
     cmake ..
+
+Configuration options can be added to the `cmake` command.  For example, you
+can change the installation directory by adding
+`-DCMAKE_INSTALL_PREFIX=/path/to/new/install/dir`.  The default is `~/.local`.
+
+Alternatively, you can configure configuration options with `ccmake ..`.
+
+If you use virtual environments for Python, you should activate your
+environment before running `cmake` and set `CMAKE_INSTALL_PREFIX` to
+the directory of the virtual environment. For example:
+
+    VIRTUAL_ENV=/path/to/virtual/env
+    $VIRTUAL_ENV/bin/activate
+    cmake -DCMAKE_INSTALL_PREFIX=$VIRTUAL_ENV
+
+Build with:
+
     make
-
-Before running make, you may wish to configure some options with
-`ccmake ..`
-
-For example, you might need to change CMAKE_INSTALL_PREFIX to a
-location accessible for writing. Default is ~/.local
 
 To run the tests, do
 
-    make test        # same as running `ctest`
+    ctest            # same as running `ctest`
     make memcheck    # runs all tests with memory checking (requires
                      # valgrind)
 
@@ -346,7 +350,7 @@ To install dlite locally, do
     make install
 
 
-### Build on Windows
+### Build with VS Code on Windows
 See [here](doc/build_with_vs.md) for detailed instructions for building with
 Visual Studio.
 

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
   test_datamodel
   test_mapping
   test_rdf
+  test_triplestore
   )
 
 foreach(test ${tests})

--- a/bindings/python/tests/test_property_mappings.py
+++ b/bindings/python/tests/test_property_mappings.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 from pathlib import Path
 
-import dlite
-import dlite.mappings as dm
-
 try:
     import pint
 except ImportError as exc:
     import sys
     print(f"Skipped: {exc}")
     sys.exit(44)  # exit code marking the test to be skipped
+
+import dlite
+import dlite.mappings as dm
 
 
 # Configure search paths

--- a/bindings/python/tests/test_python_storage.py
+++ b/bindings/python/tests/test_python_storage.py
@@ -1,10 +1,6 @@
 import os
 from pathlib import Path
 
-import rdflib
-from rdflib.util import guess_format
-from rdflib.compare import to_isomorphic
-
 import dlite
 
 try:
@@ -23,6 +19,8 @@ else:
 
 try:
     import rdflib
+    from rdflib.util import guess_format
+    from rdflib.compare import to_isomorphic
 except ImportError:
     HAVE_RDF = False
 else:

--- a/bindings/python/tests/test_rdf.py
+++ b/bindings/python/tests/test_rdf.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-import dlite
-from dlite.rdf import to_rdf, from_rdf
-
 try:
     import rdflib
 except ImportError:
     import sys
     sys.exit(44)
+
+import dlite
+from dlite.rdf import to_rdf, from_rdf
 
 
 thisdir = Path(__file__).resolve().parent

--- a/bindings/python/tests/test_triplestore.py
+++ b/bindings/python/tests/test_triplestore.py
@@ -1,3 +1,10 @@
+# Skip test if rdflib is not available
+try:
+    import rdflib
+except ImportError:
+    import sys
+    sys.exit(44)
+
 from dlite.triplestore import en, Literal, Triplestore, RDF, RDFS, XSD, OWL
 from dlite.triplestore.triplestore import function_id
 


### PR DESCRIPTION
Allow to compile DLite against Python from a virtual environment.

Added instructions to the main README file.

Skipping tests with missing Python dependencies, like rdflib, pint and psycopg2.