### PR TITLE
Allow the csv plugin to read columns with dates and times

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -109,6 +109,7 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
         inst = id
     else:
         inst = _dlite.get_instance(id, metaid, check_storages)
+
     if inst is None:
         raise DLiteError(f"no such instance: {id}")
     elif inst.is_meta:
@@ -249,9 +250,15 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
 
     # Override default generated __init__() method
     def __init__(self, *args, **kwargs):
+        if self is None:
+            raise DLiteError(f"invalid dlite.Instance")
+
         dlite.errclr()
         _dlite.Instance_swiginit(self, _dlite.new_Instance(*args, **kwargs))
-        if self.is_meta:
+
+        if not hasattr(self, 'this') or not getattr(self, 'this'):
+            raise DLiteError(f"cannot initiate dlite.Instance")
+        elif self.is_meta:
             self.__class__ = Metadata
         elif self.meta.uri == COLLECTION_ENTITY:
             self.__class__ = Collection

--- a/storages/python/python-storage-plugins/csv.py
+++ b/storages/python/python-storage-plugins/csv.py
@@ -23,8 +23,8 @@ class csv(dlite.DLiteStorageBase):  # noqa: F821
         mode: "r" | "w"
             Whether to read or write data.  Required
         meta: URI
-            URI to metadata describing the table to read.  Required if `mode`
-            is "r"
+            URI to metadata describing the table to read.  Required if
+            `infer` is false.
         infer: bool
             Whether to infer metadata from data source.  Defaults to True
         path: directories
@@ -130,7 +130,7 @@ def infer_meta(data, metauri, uri):
         fmt = ext if ext else 'csv'
         with open(uri, 'rb') as f:
             hash = hashlib.sha256(f.read()).hexdigest()
-        metauri = f'onto-ns.com/meta/1.0/generated_from_{fmt}_{hash}'
+        metauri = f'http://onto-ns.com/meta/1.0/generated_from_{fmt}_{hash}'
     elif dlite.has_instance(metauri):
         warnings.warn(f'csv option infer is true, but explicit instance id '
                       f'"{metauri}" already exists')
@@ -140,11 +140,14 @@ def infer_meta(data, metauri, uri):
     for i, col in enumerate(data.columns):
         name = infer_prop_name(col)
         type = data.dtypes[i].name
+        if type == 'object':
+            type = 'string'
         dims = ['rows']
         unit = infer_prop_unit(col)
         props.append(dlite.Property(name=name, type=type, dims=dims,
                                     unit=unit, description=None))
     descr = f'Inferred metadata for {uri}'
+
     return dlite.Instance.create_metadata(metauri, dims_, props, descr)
 
 


### PR DESCRIPTION
Fix the csv plugin such that dates and other data types that pandas convert to type "object" are treated as strings.