### PR TITLE
Interface for adding mapping cost 

### DIFF
--- a/bindings/python/mappings.py
+++ b/bindings/python/mappings.py
@@ -419,7 +419,7 @@ def mapping_route(
         #description=DCTERMS.description,
         label=RDFS.label,
         hasUnit=DM.hasUnit,
-        hasCost=':hasCost',  # TODO - add hasCost to the DM ontology
+        hasCost=DM.hasCost,  # TODO - add hasCost to the DM ontology
 ):
     """Find routes of mappings from any source in `sources` to `target`.
 
@@ -486,6 +486,14 @@ def mapping_route(
     soUnit = {s: o for s, o in triplestore.subject_objects(hasUnit)}
     soCost = {s: o for s, o in triplestore.subject_objects(hasCost)}
 
+    def getcost(target, stepname):
+        """Returns the cost assigned to IRI `target` for a mapping step
+        of type `stepname`."""
+        cost = soCost.get(target, default_costs[stepname])
+        if cost is None:
+            return None
+        return function_repo[cost] if cost in function_repo else float(cost)
+
     def walk(target, visited, step):
         """Walk backward in rdf graph from `node` to sources."""
         if target in visited: return
@@ -495,11 +503,11 @@ def mapping_route(
             if node in visited:
                 return
             step.steptype = steptype
-            step.cost = soCost.get(target, default_costs[stepname])
+            step.cost = getcost(target, stepname)
             if node in sources:
                 value = Value(value=sources[node], unit=soUnit.get(node),
                               iri=node, property_iri=soInst.get(node),
-                              cost=soCost.get(node, default_costs['value']))
+                              cost=getcost(node, 'value'))
                 step.add_input(value, name=soName.get(node))
             else:
                 prevstep = MappingStep(output_iri=node,
@@ -522,7 +530,7 @@ def mapping_route(
         for fmap in function_mappers:
             for func, input_iris in fmap(triplestore)[target]:
                 step.steptype = StepType.FUNCTION
-                step.cost = soCost.get(func, default_costs['function'])
+                step.cost = getcost(func, 'function')
                 step.function = function_repo[func]
                 step.join_mode = True
                 for i, input_iri in enumerate(input_iris):
@@ -540,7 +548,7 @@ def mapping_route(
         visited.add(target)  # do we really wan't this?
         source = soInst[target]
         step.steptype = StepType.INSTANCEOF
-        step.cost = soCost.get(source, default_costs['instanceOf'])
+        step.cost = getcost(source, 'instanceOf')
         step0 = MappingStep(output_iri=source, output_unit=soUnit.get(source))
         step.add_input(step0, name=soName.get(target))
         step = step0

--- a/bindings/python/mappings.py
+++ b/bindings/python/mappings.py
@@ -274,7 +274,7 @@ class MappingStep:
             # a callable, we call it with the input for each routeno
             # as arguments.  Otherwise `self.cost` is the cost of this
             # mapping step.
-            if isinstance(self.cost, Callable):
+            if callable(self.cost):
                 for i, rno in enumerate(base.routeno):
                     values = get_values(inputs, rno, magnitudes=True)
                     owncost = self.cost(**values)

--- a/bindings/python/tests/test_triplestore.py
+++ b/bindings/python/tests/test_triplestore.py
@@ -59,6 +59,10 @@ ts.add_mapsTo(EX.MyConcept, "http://onto-ns.com/meta/0.1/MyEntity", "myprop")
 ts.add((EX.MyConcept, RDFS.subClassOf, OWL.Thing))
 ts.add((EX.AnotherConcept, RDFS.subClassOf, OWL.Thing))
 ts.add((EX.Sum, RDFS.subClassOf, OWL.Thing))
+assert ts.has(EX.Sum) == True
+assert ts.has(EX.Sum, RDFS.subClassOf, OWL.Thing) == True
+assert ts.has(object=EX.NotInOntology) == False
+
 
 def sum(a, b):
     """Summarise `a` and `b`."""
@@ -108,4 +112,27 @@ ts2 = Triplestore("rdflib")
 ts2.parse(format="turtle", data=s)
 assert ts2.serialize(format="turtle") == s
 ts2.set((EX.AnotherConcept, RDFS.subClassOf, EX.MyConcept))
-# print(ts2.serialize(format="turtle"))
+
+def cost(x):
+    return 2*x
+
+ts2.add_mapsTo(EX.Sum, "http://onto-ns.com/meta/0.1/MyEntity#sum", cost=cost)
+assert list(ts2.function_repo.values())[0] == cost
+
+def func(x):
+    return x+1
+
+ts2.add_function(func, expects=EX.Sum, returns=EX.OneMore, cost=cost)
+assert list(ts2.function_repo.values())[1] == func
+assert len(ts2.function_repo) == 2  # cost is only added once
+
+def func2(x):
+    return x+2
+
+def cost2(x):
+    return 2*x+1
+
+ts2.add_function(func2, expects=EX.Sum, returns=EX.EvenMore, cost=cost2)
+assert len(ts2.function_repo) == 4
+
+#print(ts2.serialize(format="turtle"))

--- a/bindings/python/triplestore/triplestore.py
+++ b/bindings/python/triplestore/triplestore.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Mapping
-    from typing import Generator, Tuple, Union
+    from typing import Callable, Generator, Tuple, Union
 
     Triple = Tuple[Union[str, None], Union[str, None], Union[str, None]]
 
@@ -392,6 +392,17 @@ class Triplestore:
         self.remove((s, p, None))
         self.add(triple)
 
+    def has(self, subject=None, predicate=None, object=None):
+        """Returns true if the triplestore has any triple matching
+        the give subject, predicate and/or object."""
+        g = self.triples((subject, predicate, object))
+        try:
+            g.__next__()
+        except StopIteration:
+            return False
+        return True
+
+
     # Methods providing additional functionality
     # ------------------------------------------
     def expand_iri(self, iri: str):
@@ -421,11 +432,14 @@ class Triplestore:
                 raise NamespaceError(f"No prefix defined for IRI: {iri}")
         return iri
 
-    def add_mapsTo(self,
-                   target: str,
-                   source: "Union[str, dlite.Instance, dataclass]",
-                   property_name: str = None
-                   ):
+    def add_mapsTo(
+            self,
+            target: str,
+            source: "Union[str, dlite.Instance, dataclass]",
+            property_name: str = None,
+            cost: "Union[float, Callable]" = None,
+            target_cost: bool = True,
+    ):
         """Add 'mapsTo' relation to triplestore.
 
         Parameters:
@@ -433,6 +447,12 @@ class Triplestore:
             source: Source IRI or entity object.
             property_name: Name of property if `source` is an entity or
                 an entity IRI.
+            cost: User-defined cost of following this mapping relation
+                represented as a float.  It may be given either as a
+                float or as a callable taking the value of the mapped
+                quantity as input and returning the cost as a float.
+            target_cost: Whether the cost is assigned to mapping steps
+                that have `target` as output.
         """
         self.bind("map", MAP)
 
@@ -445,14 +465,19 @@ class Triplestore:
         if property_name:
             source = f"{source}#{property_name}"
             self.add((source, MAP.mapsTo, target))
+        if cost is not None:
+            dest = target if target_cost else source
+            self._add_cost(cost, dest)
 
-    def add_function(self,
-                     func: callable,
-                     expects: "Union[Sequence, Mapping]" = (),
-                     returns: "Union[str, Sequence]" = (),
-                     base_iri: str = None,
-                     standard: str = 'fno',
-                     ):
+    def add_function(
+            self,
+            func: callable,
+            expects: "Union[Sequence, Mapping]" = (),
+            returns: "Union[str, Sequence]" = (),
+            base_iri: str = None,
+            standard: str = 'fno',
+            cost: "Union[float, Callable]" = None,
+    ):
         """Inspect function and add triples describing it to the triplestore.
 
         Parameters:
@@ -462,9 +487,14 @@ class Triplestore:
                 dict mapping argument names to corresponding ontological IRIs.
             returns: IRI of return value.  May also be given as a sequence
                 of IRIs, if multiple values are returned.
-            base_iri:
+            base_iri: Base of the IRI representing the function in the
+                knowledge base.  Defaults to the base IRI of the triplestore.
             standard: Name of ontology to use when describing the function.
                 Defaults to the Function Ontology (FnO).
+            cost: User-defined cost of following this mapping relation
+                represented as a float.  It may be given either as a
+                float or as a callable taking the same arguments as `func`
+                returning the cost as a float.
 
         Returns:
             func_iri: IRI of the added function.
@@ -472,7 +502,33 @@ class Triplestore:
         method = getattr(self, f"_add_function_{standard}")
         func_iri = method(func, expects, returns, base_iri)
         self.function_repo[func_iri] = func
+
+        if cost is not None:
+            dests = [returns] if isinstance(returns, str) else returns
+            for dest in dests:
+                self._add_cost(cost, dest)
+
         return func_iri
+
+    def _add_cost(self, cost, dest):
+        """Help function that adds `cost` to destination IRI `dest`.
+
+        `cost` should be either a float or a Callable returning a float.
+
+        If `cost` is a callable it is just referred to with a literal
+        id and is not ontologically described as a function.  The
+        expected input arguments depends on the context, which is why
+        this function is not part of the public API.  Use the add_mapsTo()
+        and add_function() methods instead.
+        """
+        if self.has(dest, DM.hasCost):
+            warnings.warn(f"A cost is already assigned to IRI: {dest}")
+        elif isinstance(cost, callable):
+            cost_id = f"cost_function{function_id(cost)}"
+            self.add((dest, DM.hasCost, Literal(cost_id)))
+            self.function_repo[cost_id] = cost
+        else:
+            self.add((dest, DM.hasCost, Literal(cost)))
 
     def _add_function_fno(self, func, expects, returns, base_iri):
         """Implementing add_function() for FnO."""


### PR DESCRIPTION
Added options to add_mapsTo() and add_function() to provide a user-defined cost. 

The cost may be a float or a function returning the cost. Note that even if the cost is specified as a function, it is only represented in the knowledgebase as a literal identifier, without a fully ontological description of its arguments using e.g. FnO.
