### PR TITLE
Improved Python interface for dlite properties

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -193,9 +193,16 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
 
     type = property(get_type, doc='Type name.')
     dtype = property(get_dtype, doc='Type number.')
-    dims = property(get_dims, doc='Array of dimension indices. '
-                    '`dims` is deprecated, use `shape` instead.')
-    shape = property(get_dims, doc='Array of dimension indices.')
+    shape = property(get_dims, set_dims, doc='Array of dimension indices.')
+
+    # Too be removed...
+    def get_dims_depr(self):
+        warnings.warn('Property `dims` is deprecated, use `shape` instead.',
+                      DeprecationWarning, stacklevel=2)
+        return self.get_dims()
+    dims = property(get_dims_depr, doc='Array of dimension indices. '
+                    'Property `dims` is deprecated, use `shape` instead.')
+
   %}
 }
 

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -67,6 +67,14 @@ class Metadata(Instance):
             return lst[0]
         raise DLiteError(f"Metadata {self.uri} has no such property: {name}")
 
+    def dimnames(self):
+        """Returns a list of all dimension names in this metadata."""
+        return [d.name for d in self.properties['dimensions']]
+
+    def propnames(self):
+        """Returns a list of all property names in this metadata."""
+        return [p.name for p in self.properties['properties']]
+
 
 def standardise(v, prop, asdict=False):
     """Represent property value `v` as a standard python type.
@@ -152,11 +160,11 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
 %extend _DLiteProperty {
   %pythoncode %{
     def __repr__(self):
-        dims = ', dims=%r' % self.dims.tolist() if self.ndims else ''
+        shape = ', shape=%r' % self.shape.tolist() if self.ndims else ''
         unit = ', unit=%r' % self.unit if self.unit else ''
         descr = ', description=%r' %self.description if self.description else ''
         return 'Property(%r, type=%r%s%s%s)' % (
-            self.name, self.type, dims, unit, descr)
+            self.name, self.type, shape, unit, descr)
 
     def asdict(self, soft7=True, exclude_name=False):
         """Returns a dict representation of self.
@@ -170,7 +178,7 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
             d['name'] = self.name
         d['type'] = self.get_type()
         if self.ndims:
-            d['shape' if soft7 else 'dims'] = self.dims.tolist()
+            d['shape' if soft7 else 'dims'] = self.shape.tolist()
         if self.unit:
             d['unit'] = self.unit
         if self.description:
@@ -179,13 +187,15 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
 
     def asstrings(self):
         """Returns a representation of self as a tuple of strings."""
-        return (self.name, self.type, ','.join(str(d) for d in self.dims),
+        return (self.name, self.type, ','.join(str(d) for d in self.shape),
                 '' if self.unit is None else self.unit,
                 '' if self.description is None else self.description)
 
     type = property(get_type, doc='Type name.')
     dtype = property(get_dtype, doc='Type number.')
-    dims = property(get_dims, doc='Array of dimension indices.')
+    dims = property(get_dims, doc='Array of dimension indices. '
+                    '`dims` is deprecated, use `shape` instead.')
+    shape = property(get_dims, doc='Array of dimension indices.')
   %}
 }
 

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -16,6 +16,10 @@ else:
 import numpy as np
 
 
+class InvalidMetadataError:
+    """Malformed or invalid metadata."""
+
+
 class InstanceEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, (bytes, bytearray)):
@@ -62,6 +66,10 @@ class Metadata(Instance):
 
     def getprop(self, name):
         """Returns the metadata property object with the given name."""
+        if "properties" not in self.properties:
+            raise InvalidMetadataError(
+                'self.properties on metadata must contain a "properties" item'
+            )
         lst = [p for p in self.properties["properties"] if p.name == name]
         if lst:
             return lst[0]
@@ -69,10 +77,16 @@ class Metadata(Instance):
 
     def dimnames(self):
         """Returns a list of all dimension names in this metadata."""
+        if "dimensions" not in self.properties:
+            return []
         return [d.name for d in self.properties['dimensions']]
 
     def propnames(self):
         """Returns a list of all property names in this metadata."""
+        if "properties" not in self.properties:
+            raise InvalidMetadataError(
+                'self.properties on metadata must contain a "properties" item'
+            )
         return [p.name for p in self.properties['properties']]
 
 

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -193,14 +193,14 @@ def get_instance(id: "str", metaid: "str"=None, check_storages: "bool"=True) -> 
 
     type = property(get_type, doc='Type name.')
     dtype = property(get_dtype, doc='Type number.')
-    shape = property(get_dims, set_dims, doc='Array of dimension indices.')
+    shape = property(get_shape, set_shape, doc='Array of dimension indices.')
 
     # Too be removed...
-    def get_dims_depr(self):
+    def _get_dims_depr(self):
         warnings.warn('Property `dims` is deprecated, use `shape` instead.',
                       DeprecationWarning, stacklevel=2)
-        return self.get_dims()
-    dims = property(get_dims_depr, doc='Array of dimension indices. '
+        return self.get_shape()
+    dims = property(_get_dims_depr, doc='Array of dimension indices. '
                     'Property `dims` is deprecated, use `shape` instead.')
 
   %}

--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -176,21 +176,25 @@ struct _DLiteProperty {
   }
   void set_dims(obj_t *arr) {
     int i, n = dlite_swig_length(arr);
+    char **new=NULL;
+    if (!(new = calloc(n, sizeof(char *))))
+      FAIL("allocation failure");
+    if (dlite_swig_set_array(&new, 1, &n, dliteStringPtr, sizeof(char *), arr))
+      FAIL("cannot set new shape");
     for (i=0; i < $self->ndims; i++) free($self->dims[i]);
     free($self->dims);
-    $self->ndims = 0;
-    if (n) {
-      if (!($self->dims = calloc(n, sizeof(char *)))) {
-        dlite_err(1, "allocation failure");
-        return;
-      }
-    }
     $self->ndims = n;
-    if (dlite_swig_set_array(&$self->dims, 1, &$self->ndims,
-                             dliteStringPtr, sizeof(char *), arr))
-      dlite_err(1, "cannot set new shape");
+    $self->dims = new;
+    return;
+  fail:
+    if (new) {
+      for (i=0; i<n; i++) if(new[i]) free(new[i]);
+      free(new);
+    }
   }
+
 }
+
 
 /* --------
  * Relation

--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -170,11 +170,11 @@ struct _DLiteProperty {
   int get_dtype(void) {
     return $self->type;
   }
-  obj_t *get_dims(void) {
+  obj_t *get_shape(void) {
     return dlite_swig_get_array(NULL, 1, &$self->ndims,
                                 dliteStringPtr, sizeof(char *), $self->dims);
   }
-  void set_dims(obj_t *arr) {
+  void set_shape(obj_t *arr) {
     int i, n = dlite_swig_length(arr);
     char **new=NULL;
     if (!(new = calloc(n, sizeof(char *))))

--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -137,7 +137,10 @@ Property(seq)
 struct _DLiteProperty {
   char *name;
   size_t size;
+  char *ref;
+  %immutable;
   int ndims;
+  %mutable;
   char *unit;
   char *description;
 };
@@ -171,10 +174,22 @@ struct _DLiteProperty {
     return dlite_swig_get_array(NULL, 1, &$self->ndims,
                                 dliteStringPtr, sizeof(char *), $self->dims);
   }
-  /*
   void set_dims(obj_t *arr) {
+    int i, n = dlite_swig_length(arr);
+    for (i=0; i < $self->ndims; i++) free($self->dims[i]);
+    free($self->dims);
+    $self->ndims = 0;
+    if (n) {
+      if (!($self->dims = calloc(n, sizeof(char *)))) {
+        dlite_err(1, "allocation failure");
+        return;
+      }
+    }
+    $self->ndims = n;
+    if (dlite_swig_set_array(&$self->dims, 1, &$self->ndims,
+                             dliteStringPtr, sizeof(char *), arr))
+      dlite_err(1, "cannot set new shape");
   }
-  */
 }
 
 /* --------

--- a/bindings/python/dlite-python.i
+++ b/bindings/python/dlite-python.i
@@ -242,6 +242,14 @@ int dlite_swig_read_python_blob(PyObject *src, uint8_t *dest, size_t n)
 }
 
 
+/* Returns the length of sequence-like object.  On error, -1 is returned. */
+size_t dlite_swig_length(obj_t *obj)
+{
+  return (size_t)PyObject_Length(obj);
+}
+
+
+
 /**********************************************
  ** Python-specific implementations
  **********************************************/

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -148,7 +148,7 @@ prop = Property("a", type='float')
 
 prop2 = Property("b", type='string10', dims=['I', 'J', 'K'],
                  description='something enlightening...')
-assert any(prop2.dims)
+assert any(prop2.shape)
 
 props = myentity['properties']
 props[0]

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -8,6 +8,13 @@ import numpy as np
 import dlite
 from dlite import Instance, Dimension, Property, Relation
 
+try:
+    import pytest
+    HAVE_PYTEST = True
+except ImportError:
+    HAVE_PYTEST = False
+
+
 thisdir = os.path.abspath(os.path.dirname(__file__))
 
 url = 'json://' + thisdir + '/MyEntity.json'
@@ -183,6 +190,38 @@ except ImportError:
     pass
 else:
     inst.save('yaml://yyy.yaml?mode=w')
+
+
+# Test metadata
+assert inst.meta.dimnames() == ['N', 'M']
+assert inst.meta.propnames() == [
+    'a-blob',
+    'a-blob-array',
+    'a-bool',
+    'a-bool-array',
+    'an-int',
+    'an-int-array',
+    'a-float',
+    'a-float64-array',
+    'a-fixstring',
+    'a-fixstring-array',
+    'a-string',
+    'a-string-array',
+    'a-relation',
+    'a-relation-array',
+]
+prop = inst.meta.getprop('a-blob-array')
+assert prop.name == 'a-blob-array'
+assert prop.type == 'blob4'
+assert prop.shape.tolist() == ['N', 'N']
+assert prop.unit == None
+assert prop.description == 'A blob array.'
+
+prop = dlite.Property('newprop', 'int')
+prop.set_dims(('a', 'b', 'c'))
+if HAVE_PYTEST:
+    with pytest.raises(AttributeError):
+        prop.ndims = 10
 
 del inst
 del e2

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -210,6 +210,9 @@ assert inst.meta.propnames() == [
     'a-relation',
     'a-relation-array',
 ]
+
+
+# Test property
 prop = inst.meta.getprop('a-blob-array')
 assert prop.name == 'a-blob-array'
 assert prop.type == 'blob4'

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -218,7 +218,8 @@ assert prop.unit == None
 assert prop.description == 'A blob array.'
 
 prop = dlite.Property('newprop', 'int')
-prop.set_dims(('a', 'b', 'c'))
+prop.shape = ('a', 'b', 'c')
+assert prop.ndims == 3
 if HAVE_PYTEST:
     with pytest.raises(AttributeError):
         prop.ndims = 10


### PR DESCRIPTION
* Added convinient dimnames() and propnames() functions to Metadata.
* Changed some occurences of `dims` to `shape` in Python interface to properties
* Allow to set property shape
* Made Property.ndims immutable
* Added tests
