### PR TITLE
Set the SETUPTOOLS_USE_DISTUTILS env var for musslinux

### DIFF
--- a/.github/docker/Dockerfile-musllinux.template
+++ b/.github/docker/Dockerfile-musllinux.template
@@ -25,6 +25,11 @@ FROM quay.io/pypa/musllinux{{ TYPE }}_{{ ARCH }}:latest
 
 COPY requirements.txt /tmp/requirements.txt
 
+# Do not use distutils distributed with setuptools
+# This is due to base changes in the distutils API, removing msvccompiler,
+# which is necessary for building the numpy wheel.
+ENV SETUPTOOLS_USE_DISTUTILS="stdlib"
+
 RUN apk add -u \
   redland \
   rasqal \


### PR DESCRIPTION
Fixes #316 

v65 of `setuptools` removed the `msvccompiler` module under `distutils`, which NumPy depends on to build its wheel.
Setting the `SETUPTOOLS_USE_DISTUTILS` environment variable to `stdlib`, making `setuptools` use the built-in `distutils` instead of the version it bundles.

I tested this locally by building the `musllinux` Docker image and run `cibuildwheel` with this image.

What needs to be done now is to merge this, run the [weekly image workflow](https://github.com/SINTEF/dlite/actions/workflows/container_builds_weekly.yml) to generate a new `musllinux` image, which can be used in the CI jobs.
**Note**: The CI job will _not_ work for this PR at this stage.

I tried to add this environment variable to `pyproject.toml`, but I couldn't find a decent way to add this variable _only_ to the `musllinux` build, meaning it would also be set for all other platform, something that I don't see as desireable.