### PR TITLE
Fixed doxygen warnings

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -46,6 +46,7 @@ if(DOXYGEN_FOUND)
     ${dlite_SOURCE_DIR}/doc/storage_plugins.md
     ${dlite_SOURCE_DIR}/doc/tools.md
     ${dlite_SOURCE_DIR}/doc/transactions.md
+    ${dlite_SOURCE_DIR}/doc/developers/release_instructions.md
     ${dlite_SOURCE_DIR}/doc/figs/transactions.png
 
     ${dlite_SOURCE_DIR}/src/dlite.h

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -776,6 +776,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @dlite_SOURCE_DIR@/doc \
+                         @dlite_SOURCE_DIR@/doc/developers \
                          @dlite_BINARY_DIR@/doc/README.md \
                          @dlite_SOURCE_DIR@/doc/concepts.md \
                          @dlite_SOURCE_DIR@/doc/transactions.md \

--- a/doc/fix_readme.cmake
+++ b/doc/fix_readme.cmake
@@ -2,13 +2,20 @@
 
 file(READ ${infile} content)
 
-# Fix markdown links
+# Fix markdown links to .md files in subdirectories of doc/
 string(REGEX REPLACE
-  "\\[([^]]*)\\]\\(doc/([^\\.]*)\\.md\\)"
-  "\n@ref md_doc_\\2\n"
-  #"\n@ref md_doc_\\2 \"\\1\"\n"
-  replaced
+  "\\[([^]]*)\\]\\(doc/([^/]*)/([^\\.]*)\\.md\\)"
+  "\n@ref md_doc_\\2_\\3\n"
+  replaced1
   "${content}"
   )
 
-file(WRITE ${outfile} "${replaced}")
+# Fix markdown links to .md files in doc/
+string(REGEX REPLACE
+  "\\[([^]]*)\\]\\(doc/([^\\.]*)\\.md\\)"
+  "\n@ref md_doc_\\2\n"
+  replaced2
+  "${replaced1}"
+  )
+
+file(WRITE ${outfile} "${replaced2}")


### PR DESCRIPTION
Closes #358 

- Included markdown files in doc/ subdirectories
- Replace slash (dir separator) with underscore in generated references to markdown files