### PR TITLE
Ignore lines with the STRINGIFY() macro, which cppcheck suddenly started to compain about

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,6 +19,10 @@ jobs:
       run: |
         sudo apt-get install cppcheck
 
+    - name: Show cppcheck version
+      run: |
+        cppcheck --version
+
     - name: Run static code analysis
       run: |
         # We ignore src/utils/tests/test_tgen.c due to a strange bug in the

--- a/src/tests/test_json.c
+++ b/src/tests/test_json.c
@@ -19,7 +19,7 @@ DLiteMeta *meta=NULL;
 MU_TEST(test_load)
 {
   char *url;
-  url = PREFIX "test-entity.json?mode=r";
+  url = PREFIX "test-entity.json?mode=r";  // cppcheck-suppress unknownMacro
   meta = dlite_meta_load_url(url);
   mu_check(meta);
 

--- a/src/tests/test_storage.c
+++ b/src/tests/test_storage.c
@@ -20,7 +20,7 @@ MU_TEST(test_open)
 MU_TEST(test_open_url)
 {
   char *url =
-    "json://" STRINGIFY(dlite_SOURCE_DIR) "/src/tests/test-data.json?mode=r";
+    "json://" STRINGIFY(dlite_SOURCE_DIR) "/src/tests/test-data.json?mode=r";  // cppcheck-suppress unknownMacro
   mu_assert_int_eq(0, dlite_storage_close(s));
   mu_check((s = dlite_storage_open_url(url)));
   mu_assert_int_eq(0, dlite_storage_is_writable(s));

--- a/storages/json/tests/test_json_storage.c
+++ b/storages/json/tests/test_json_storage.c
@@ -117,9 +117,9 @@ MU_TEST(test_load)
 
 MU_TEST(test_load2)
 {
-  char *url = "json://" STRINGIFY(DLITE_ROOT)
-    "/src/tests/test-read-data.json"
-    "#dlite/1/test-c";  // cppcheck-suppress unknownMacro
+  char *url = "json://"
+    STRINGIFY(DLITE_ROOT)  // cppcheck-suppress unknownMacro
+    "/src/tests/test-read-data.json#dlite/1/test-c";
   printf("\n--- test_load2: %s ---\n", url);
 
   DLiteInstance *inst2 = dlite_instance_load_url(url);

--- a/storages/json/tests/test_json_storage.c
+++ b/storages/json/tests/test_json_storage.c
@@ -117,8 +117,9 @@ MU_TEST(test_load)
 
 MU_TEST(test_load2)
 {
-  char *url = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-read-data.json"
-    "#dlite/1/test-c";
+  char *url = "json://" STRINGIFY(DLITE_ROOT)
+    "/src/tests/test-read-data.json"
+    "#dlite/1/test-c";  // cppcheck-suppress unknownMacro
   printf("\n--- test_load2: %s ---\n", url);
 
   DLiteInstance *inst2 = dlite_instance_load_url(url);

--- a/storages/python/tests-c/test_blob_storage.c
+++ b/storages/python/tests-c/test_blob_storage.c
@@ -16,7 +16,7 @@ DLiteInstance *inst = NULL;
 MU_TEST(test_load)
 {
   char *url = "blob://" STRINGIFY(CURRENT_SOURCE_DIR)
-    "/test_blob_storage.c?mode=r";
+    "/test_blob_storage.c?mode=r";  // cppcheck-suppress unknownMacro
   inst = dlite_instance_load_url(url);
   mu_check(inst);
 }

--- a/storages/python/tests-c/test_blob_storage.c
+++ b/storages/python/tests-c/test_blob_storage.c
@@ -15,8 +15,9 @@ DLiteInstance *inst = NULL;
 
 MU_TEST(test_load)
 {
-  char *url = "blob://" STRINGIFY(CURRENT_SOURCE_DIR)
-    "/test_blob_storage.c?mode=r";  // cppcheck-suppress unknownMacro
+  char *url = "blob://"
+    STRINGIFY(CURRENT_SOURCE_DIR)  // cppcheck-suppress unknownMacro
+    "/test_blob_storage.c?mode=r";
   inst = dlite_instance_load_url(url);
   mu_check(inst);
 }

--- a/storages/python/tests-c/test_bson_storage.c
+++ b/storages/python/tests-c/test_bson_storage.c
@@ -9,8 +9,9 @@ MU_TEST(test_save)
   DLiteStorage* s = NULL;
 
   // Load JSON metadata
-  char* url
-	  = "json://" STRINGIFY(DLITE_ROOT) "/src/tests/test-entity.json?mode=r";
+  char* url =
+    "json://" STRINGIFY(DLITE_ROOT)
+    "/src/tests/test-entity.json?mode=r";  // cppcheck-suppress unknownMacro
   DLiteInstance* meta = (DLiteInstance*)dlite_meta_load_url(url);
   mu_check(meta);
   mu_check(dlite_instance_is_meta(meta));

--- a/storages/python/tests-c/test_bson_storage.c
+++ b/storages/python/tests-c/test_bson_storage.c
@@ -10,8 +10,8 @@ MU_TEST(test_save)
 
   // Load JSON metadata
   char* url =
-    "json://" STRINGIFY(DLITE_ROOT)
-    "/src/tests/test-entity.json?mode=r";  // cppcheck-suppress unknownMacro
+    "json://" STRINGIFY(DLITE_ROOT)  // cppcheck-suppress unknownMacro
+    "/src/tests/test-entity.json?mode=r";
   DLiteInstance* meta = (DLiteInstance*)dlite_meta_load_url(url);
   mu_check(meta);
   mu_check(dlite_instance_is_meta(meta));

--- a/storages/rdf/tests/test_rdf.c
+++ b/storages/rdf/tests/test_rdf.c
@@ -12,8 +12,9 @@ DLiteMeta *meta=NULL;
 MU_TEST(test_load_inst)
 {
   char *url;
-  url = "json://" STRINGIFY(dlite_SOURCE_DIR)
-    "/src/tests/test-entity.json?mode=r";  // cppcheck-suppress unknownMacro
+  url = "json://"
+    STRINGIFY(dlite_SOURCE_DIR)  // cppcheck-suppress unknownMacro
+    "/src/tests/test-entity.json?mode=r";
   meta = dlite_meta_load_url(url);
   mu_check(meta);
 

--- a/storages/rdf/tests/test_rdf.c
+++ b/storages/rdf/tests/test_rdf.c
@@ -12,7 +12,8 @@ DLiteMeta *meta=NULL;
 MU_TEST(test_load_inst)
 {
   char *url;
-  url="json://"STRINGIFY(dlite_SOURCE_DIR)"/src/tests/test-entity.json?mode=r";
+  url = "json://" STRINGIFY(dlite_SOURCE_DIR)
+    "/src/tests/test-entity.json?mode=r";  // cppcheck-suppress unknownMacro
   meta = dlite_meta_load_url(url);
   mu_check(meta);
 


### PR DESCRIPTION
Closes #372 

cppcheck v2.7.4 works fine, but the version on github has suddenly started to complain about STRINGIFY() being an unknown macro. 

A better solution would be to use a newer version of cppcheck in the github CI, but for now ignoring the lines that triggers cppcheck gets us going...
