### PR TITLE
Improve error reporting for missing dimensions, properties and/or relations

### DIFF
--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -494,9 +494,8 @@ static DLiteInstance *parse_instance(const char *src, jsmntok_t *obj,
     if (dlite_get_uuid(uuid2, id) < 0) goto fail;
     if (strcmp(uuid, uuid2) != 0)
       FAIL3("instance has id \"%s\", expected \"%s\" (%s)", uuid, uuid2, id);
-  } else {
-    id = (uri) ? uri : uuid;
   }
+  id = (uri) ? uri : uuid;
 
   /* Get metadata */
   if ((item = jsmn_item(src, obj, "meta"))) {
@@ -524,8 +523,8 @@ static DLiteInstance *parse_instance(const char *src, jsmntok_t *obj,
     if ((t = jsmn_item(src, obj, "properties"))) dims[n++] = t->size;
     if ((t = jsmn_item(src, obj, "relations")))  dims[n++] = t->size;
     if (n != meta->_ndimensions)
-      FAIL3("expected %d dimensions, got %d: %s",
-            (int)meta->_ndimensions, (int)n, id);
+      FAIL1("metadata does not confirm to schema, check dimensions, "
+            "properties and/or relations: %s", id);
 
   } else {
     if (meta->_ndimensions > 0) {

--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -495,7 +495,7 @@ static DLiteInstance *parse_instance(const char *src, jsmntok_t *obj,
     if (strcmp(uuid, uuid2) != 0)
       FAIL3("instance has id \"%s\", expected \"%s\" (%s)", uuid, uuid2, id);
   }
-  id = (uri) ? uri : uuid;
+  if (uri) id = uri;
 
   /* Get metadata */
   if ((item = jsmn_item(src, obj, "meta"))) {
@@ -523,7 +523,7 @@ static DLiteInstance *parse_instance(const char *src, jsmntok_t *obj,
     if ((t = jsmn_item(src, obj, "properties"))) dims[n++] = t->size;
     if ((t = jsmn_item(src, obj, "relations")))  dims[n++] = t->size;
     if (n != meta->_ndimensions)
-      FAIL1("metadata does not confirm to schema, check dimensions, "
+      FAIL1("metadata does not confirm to schema, please check dimensions, "
             "properties and/or relations: %s", id);
 
   } else {


### PR DESCRIPTION
Closes #353 

This solution may not be perfect, but hopefulle it is an improvement. A missing dimension should now result in the following message:

    DLiteError: Error 1: metadata does not confirm to schema, please check dimensions, properties and/or 
    relations: http://onto-ns.com/test/0.1/ch

It is understandable? It is possible to add more finegrained checks for missing/unexpected dimensions, properties and/or relations, but it will require more code.