### PR TITLE
Made install rule for FORTRAN modules when FORTRAN bindings are built

### DIFF
--- a/bindings/fortran/CMakeLists.txt
+++ b/bindings/fortran/CMakeLists.txt
@@ -16,6 +16,20 @@ target_link_libraries(dlite-fortran
   )
 
 
+## create list of modules to install from ${sources}
+set(modules "")
+foreach(source ${sources})
+  string(REPLACE ".f90" ".mod" module ${source})
+  if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${module})
+      list(APPEND modules ${CMAKE_CURRENT_BINARY_DIR}/${module})
+  endif()
+endforeach()
+set_target_properties(dlite-fortran PROPERTIES PUBLIC_HEADER "${modules}")
+
+## Install modules in 
+install(TARGETS dlite-fortran
+  PUBLIC_HEADER DESTINATION include/dlite
+)
 
 
 add_subdirectory(tests)


### PR DESCRIPTION
This fixes the problem with missing modules when FORTRAN modules are built and installed