### PR TITLE
474 fix python documentation requirements

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -16,4 +16,4 @@ sphinxcontrib-plantuml~=0.24
 
 
 nbclient<0.6,>=0.2
-# docutils<0.18,>=0.14
+docutils<0.18,>=0.14

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,8 +3,8 @@ breathe>=4.34.0
 beautifulsoup4>=4.11.1
 lxml>=4.7.1
 myst-nb~=0.17.1
-Sphinx>=4.5.0,<6
-#sphinx>=4.5.0,<5
+
+Sphinx>=4.5.0,<5
 
 sphinx-autoapi~=2.0
 sphinx-autobuild~=2021.3.14

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -4,9 +4,16 @@ beautifulsoup4>=4.11.1
 lxml>=4.7.1
 myst-nb~=0.17.1
 Sphinx>=4.5.0,<6
+#sphinx>=4.5.0,<5
+
 sphinx-autoapi~=2.0
 sphinx-autobuild~=2021.3.14
 sphinx-book-theme~=0.3.3
 sphinx-copybutton~=0.5.1
 sphinx-design~=0.3.0
 sphinxcontrib-plantuml~=0.24
+
+
+
+nbclient<0.6,>=0.2
+# docutils<0.18,>=0.14


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Addressing issue #474 

Added `nbclient<0.6,>=0.2` to fix `jupyter-cache` error. Changed `Sphinx>=4.5.0,<6` to `<Sphinx>=4.5.0,<5` to fix `pydata-sphinx-theme` and `sphinx-book-theme` errors. This raised an incompatibility with `docutils`, which was fixed by adding `docutils<0.18,>=0.14`. 

No errors in the installation.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
