### PR TITLE
Recursive directory creation for unit registry cache

### DIFF
--- a/bindings/python/triplestore/units.py
+++ b/bindings/python/triplestore/units.py
@@ -63,7 +63,7 @@ def prepare_cache_file_path(filename: str) -> str:
     """Return cache file name."""
     cache_directory = user_cache_dir("dlite")
     if not os.path.exists(cache_directory):
-        os.mkdir(cache_directory)
+        os.makedirs(cache_directory)
     return os.path.join(cache_directory, filename)
 
 

--- a/bindings/python/triplestore/units.py
+++ b/bindings/python/triplestore/units.py
@@ -81,7 +81,7 @@ def get_pint_registry(sources=('qudt', ), force_recreate=False) -> UnitRegistry:
     """
     registry_file_path = prepare_cache_file_path("pint_unit_registry.txt")
     if force_recreate or not os.path.exists(registry_file_path):
-        with open(registry_file_path, "w") as f:
+        with open(registry_file_path, "w", encoding="utf8") as f:
             f.write("\n".join(pint_prefix_lines()) + "\n")
         for source in sources:
             pint_registry_lines = pint_registry_lines_from_qudt()

--- a/bindings/python/triplestore/units.py
+++ b/bindings/python/triplestore/units.py
@@ -85,7 +85,7 @@ def get_pint_registry(sources=('qudt', ), force_recreate=False) -> UnitRegistry:
             f.write("\n".join(pint_prefix_lines()) + "\n")
         for source in sources:
             pint_registry_lines = pint_registry_lines_from_qudt()
-            with open(registry_file_path, "a") as f:
+            with open(registry_file_path, "a", encoding="utf8") as f:
                 f.write("\n".join(pint_registry_lines) + "\n")
 
     ureg = UnitRegistry(registry_file_path)


### PR DESCRIPTION
# Description:
Change the usage of `os.mkdir()` to `os.makedirs()`, so that the cache directory for the Pint unit registry can be created in Windows. (In Windows, multiple levels of directories need to be created for the user cache path returned by `appdirs.user_cache_dir()`.) Closes #495.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
