### PR TITLE
Updated ci-tests.yml to use cmake 3.25.2

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt-get update --fix-missing
 
     - name: Workaround - install CMake 3.25.2 since 3.26.0 doesn't work
-      run |
+      run: |
         sudo apt remove cmake
         sudo apt purge --auto-remove cmake
         wget http://www.cmake.org/files/v3.25/cmake-3.25.2.tar.gz

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -9,16 +9,29 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Update submodules
-      run: |
-        git submodule init
-        git submodule update
-    - name: Get Cmake version
+    - name: apt-get update
+      run |
+        sudo apt-get update --fix-missing
+
+    - name: Workaround - install CMake 3.25.2 since 3.26.0 doesn't work
+      run |
+        sudo apt remove cmake
+        sudo apt purge --auto-remove cmake
+        wget http://www.cmake.org/files/v3.25/cmake-3.25.2.tar.gz
+        tar xf cmake-3.25.2.tar.gz
+        cd cmake-3.25.2
+        ./configure
+        make
+        sudo make install
+        hash -r
+        cd -
+
+    - name: Show CMake version
       run: |
         cmake --version
+
     - name: Install dependencies
       run: |
-        sudo apt-get update --fix-missing
         sudo apt-get install \
           libhdf5-dev \
           swig4.0 \
@@ -30,6 +43,7 @@ jobs:
           python3-numpy \
           python3-yaml \
           python3-psycopg2
+
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip -r requirements.txt


### PR DESCRIPTION
# Description:
Fix failing CI tests by downgrading cmake from 3.26.0 to cmake 3.25.2. This solves the issue of calling `find_package(dlite)` when running example ex4 as a CI test  - see issue #509.

This is only a temporary fix:
- If the issue is due to a bug in CMake 3.26.0, then this fix should be reverted when Ubuntu has updated CMake to a working version.
- If the issue is due to a bug in how we generate `dliteConfig.cmake` from `cmake/dliteConfig.cmake.in`, this fix should be reverted when we have fixed that problem.

## Type of change:
- [x] Temporary workaround.
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
