### PR TITLE
Asjson

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -21,28 +21,6 @@ class InvalidMetadataError:
     """Malformed or invalid metadata."""
 
 
-class InstanceEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, (bytes, bytearray)):
-            return obj.hex()
-        elif isinstance(obj, np.ndarray):
-            if obj.dtype.kind == 'V':
-                conv = lambda e: ([conv(ele) for ele in e]
-                                  if isinstance(e, list)
-                                  else base64.b16encode(e))
-                return conv(obj.tolist())
-            else:
-                return obj.tolist()
-        elif hasattr(obj, 'aspreferred'):
-            return obj.aspreferred()
-        elif hasattr(obj, 'asdict'):
-            return obj.asdict()
-        elif hasattr(obj, 'asstrings'):
-            return obj.asstrings()
-        else:
-            return json.JSONEncoder.default(self, obj)
-
-
 class Metadata(Instance):
     """A subclass of Instance for metadata.
 

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -626,9 +626,6 @@ def get_instance(id: "str", metaid: "str" = None, check_storages: "bool" = True)
             d['uri'] = self.uri
         d['meta'] = self.meta.uri
         if self.is_meta:
-            #d['name'] = self['name']
-            #d['version'] = self['version']
-            #d['namespace'] = self['namespace']
             d['description'] = self['description']
             if soft7:
                 d['dimensions'] = {dim.name: dim.description
@@ -648,9 +645,7 @@ def get_instance(id: "str", metaid: "str" = None, check_storages: "bool" = True)
             d['relations'] = self['relations'].tolist()
         return d
 
-
-    # Deprecated methods
-    def asjson(self, indent=0, single=False,
+    def asjson(self, indent=0, single=None,
                urikey=False, with_uuid=False, with_meta=False,
                with_arrays=False, no_parent=False,
                soft7=None, uuid=None):
@@ -658,10 +653,12 @@ def get_instance(id: "str", metaid: "str" = None, check_storages: "bool" = True)
 
         Arguments:
             indent: Number of spaces to indent each line with.
-            single: Whether to return single-entity format.
+            single: Whether to return single-entity format.  Default is
+                single-entity format for metadata and multi-entity format
+                for data instances.
             urikey: Use uri (if it exists) as JSON key in multi-entity format.
             with_uuid: Whether to include UUID in output.
-            with_meta: Always include "meta" field, even for metadata.
+            with_meta: Always include "meta" field, even for entities.
             with_arrays: Write metadata dimensions and properties as jSON
                 arrays (old format).
             no_parent: Do not include transaction parent info.
@@ -669,22 +666,29 @@ def get_instance(id: "str", metaid: "str" = None, check_storages: "bool" = True)
                 Use `with_arrays=False` instead.
             uuid: Alias for `with_uuid`. Deprecated.
         """
+        if single is None:
+            single = self.is_meta
+
         if soft7 is not None:
             warnings.warn(
                 "`soft7` argument of asjson() is deprecated, use "
                 "`with_arrays` (negated) instead.",
                  DeprecationWarning, stacklevel=2)
             with_arrays = not bool(soft7)
+
         if uuid is not None:
             warnings.warn(
                 "`uuid` argument of asjson() is deprecated, use "
                 "`with_uuid` instead.",
                  DeprecationWarning, stacklevel=2)
             with_uuid = bool(uuid)
+
         return self._asjson(indent=indent, single=single, urikey=urikey,
                             with_uuid=with_uuid, with_meta=with_meta,
                             with_arrays=with_arrays, no_parent=no_parent)
 
+
+    # Deprecated methods
     def tojson(self, indent=0, single=False,
                urikey=False, with_uuid=False, with_meta=False,
                with_arrays=False, no_parent=False,

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -670,22 +670,63 @@ def get_instance(id: "str", metaid: "str" = None, check_storages: "bool" = True)
             d['relations'] = self['relations'].tolist()
         return d
 
-    def asjson(self, soft7=True, uuid=True, **kwargs):
-        """Returns a JSON representation of self.  Keyword arguments are
-        passed to json.dumps()."""
-        return json.dumps(self.asdict(soft7=soft7, uuid=uuid),
-                          cls=InstanceEncoder, **kwargs)
 
     # Deprecated methods
+    def asjson(self, indent=0, single=False,
+               urikey=False, with_uuid=False, with_meta=False,
+               with_arrays=False, no_parent=False,
+               soft7=None, uuid=None):
+        """Returns a JSON representation of self.
+
+        Arguments:
+            indent: Number of spaces to indent each line with.
+            single: Whether to return single-entity format.
+            urikey: Use uri (if it exists) as JSON key in multi-entity format.
+            with_uuid: Whether to include UUID in output.
+            with_meta: Always include "meta" field, even for metadata.
+            with_arrays: Write metadata dimensions and properties as jSON
+                arrays (old format).
+            no_parent: Do not include transaction parent info.
+            soft7: Whether to structure metadata as SOFT7. Deprecated.
+                Use `with_arrays=False` instead.
+            uuid: Alias for `with_uuid`. Deprecated.
+        """
+        if soft7 is not None:
+            warnings.warn(
+                "`soft7` argument of asjson() is deprecated, use "
+                "`with_arrays` (negated) instead.",
+                 DeprecationWarning, stacklevel=2)
+            with_arrays = not bool(soft7)
+        if uuid is not None:
+            warnings.warn(
+                "`uuid` argument of asjson() is deprecated, use "
+                "`with_uuid` instead.",
+                 DeprecationWarning, stacklevel=2)
+            with_uuid = bool(uuid)
+        return self._asjson(indent=indent, single=single, urikey=urikey,
+                            with_uuid=with_uuid, with_meta=with_meta,
+                            with_arrays=with_arrays, no_parent=no_parent)
+
+    def tojson(self, indent=0, single=False,
+               urikey=False, with_uuid=False, with_meta=False,
+               with_arrays=False, no_parent=False,
+               soft7=None, uuid=None):
+        """Deprecated alias for asjson()."""
+        warnings.warn(
+            'tojson() is deprecated, use asjson() instead.',
+             DeprecationWarning, stacklevel=2)
+        return self._asjson(indent=indent, single=single, urikey=urikey,
+                            with_uuid=with_uuid, with_meta=with_meta,
+                            with_arrays=with_arrays, no_parent=no_parent)
+
     def get_copy(self):
         """Returns a copy of self.
 
         This method is deprecated.  Use copy() instead.
         """
         warnings.warn(
-            DeprecationWarning,
-            "Instance.get_copy() is deprecated.  Use Instance.copy() instead."
-        )
+            "Instance.get_copy() is deprecated.  Use Instance.copy() instead.",
+            DeprecationWarning, stacklevel=2)
         return self.copy()
 %}
 

--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -730,7 +730,7 @@ Returns:
   %feature("docstring",
            "Returns a JSON representation of self.") tojson;
   %newobject tojson;
-  char *tojson(int indent=0, bool single=false, bool urikey=false,
+  char *_asjson(int indent=0, bool single=false, bool urikey=false,
                bool with_uuid=false, bool with_meta=false,
                bool with_arrays=false, bool no_parent=false) {
     DLiteJsonFlag flags=0;

--- a/src/tests/test_entity.c
+++ b/src/tests/test_entity.c
@@ -315,7 +315,7 @@ MU_TEST(test_instance_snprint)
   char buf[1024];
   inst = dlite_instance_load_url("json://myentity.json?mode=r#mydata");
   mu_check(inst);
-  n = dlite_json_sprint(buf, sizeof(buf), inst, 2, 0);
+  n = dlite_json_sprint(buf, sizeof(buf), inst, 2, dliteJsonSingle);
   mu_assert_int_eq(346, n);
   dlite_instance_decref(inst);
 }

--- a/src/tests/test_json.c
+++ b/src/tests/test_json.c
@@ -35,23 +35,24 @@ MU_TEST(test_sprint)
   int m;
 
   /* soft7 format: dliteJsonArrays unset */
-  m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)meta, 0, 0);
+  m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)meta, 0,
+                        dliteJsonSingle);
   //printf("\n--------------------------------------------------------\n");
   //printf("%s\n", buf);
   mu_assert_int_eq(799, m);
 
   m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)meta, 2,
-                        dliteJsonWithUuid);
+                        dliteJsonWithUuid | dliteJsonSingle);
   //printf("\n--------------------------------------------------------\n");
   //printf("%s\n", buf);
   mu_assert_int_eq(923, m);
 
-  m = dlite_json_sprint(buf, sizeof(buf), inst, 4, 0);
+  m = dlite_json_sprint(buf, sizeof(buf), inst, 4, dliteJsonSingle);
   //printf("\n--------------------------------------------------------\n");
   //printf("%s\n", buf);
   mu_assert_int_eq(404, m);
 
-  m = dlite_json_sprint(buf, 80, inst, 4, 0);
+  m = dlite_json_sprint(buf, 80, inst, 4, dliteJsonSingle);
   //printf("\n--------------------------------------------------------\n");
   //printf("%s\n", buf);
   mu_assert_int_eq(404, m);
@@ -60,13 +61,13 @@ MU_TEST(test_sprint)
 
   /* soft5 format: dliteJsonArrays set */
   m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)meta, 0,
-                        dliteJsonArrays);
+                        dliteJsonArrays | dliteJsonSingle);
   //printf("\n--------------------------------------------------------\n");
   //printf("%s\n", buf);
   mu_assert_int_eq(1011, m);
 
   m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)meta, 2,
-                        dliteJsonWithUuid | dliteJsonArrays);
+                        dliteJsonWithUuid | dliteJsonArrays | dliteJsonSingle);
   //printf("\n--------------------------------------------------------\n");
   //printf("%s\n", buf);
   mu_assert_int_eq(1165, m);


### PR DESCRIPTION
# Description:
Update Instance.asjson() to use the builtin json serialiser instead of the Python standard json library. This ensures that:
- The json serialisation from Instance.asjson() is consistent with json serialisation from C.
- That json serialisation of data of ref type is serialised by reference, not as nested structures (which may be misleading).
- That json serialisation of data of ref type with cyclic references doesn't hang.
- That all the flags controlling the json output is available via the `asjson()` method.
- That the argument `single` of `asjson()` has an effect.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
