### PR TITLE
Workaround for new version of cmake not defining <project>_VERSION_PATCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(dlite
-  VERSION 3.19
+  VERSION 0.3.19
   DESCRIPTION "Lightweight data-centric framework for semantic interoperability"
   HOMEPAGE_URL "https://github.com/SINTEF/dlite"
   LANGUAGES C

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -8,8 +8,9 @@
 #endif
 //#include "config-paths.h"
 
-/* Macro magic to expand defined variables to 1 */
-#define DO_ISEMPTY(VAL)  VAL ## 1
+/* Macro magic that expands a defined but empty variable to 1.
+ * `VAL` must be empty or a non-negative integer. */
+#define DO_ISEMPTY(VAL)  1 ## VAL
 #define ISEMPTY(VAL)     DO_ISEMPTY(VAL)
 
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,12 +20,9 @@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
-/* Require major and minor versions to be defined */
-#if !defined(dlite_VERSION_MAJOR) || ISEMPTY(dlite_VERSION_MAJOR) == 1
-# error "Major version number must be defined in main CMakeLists.txt"
-#endif
-#if !defined(dlite_VERSION_MINOR) || ISEMPTY(dlite_VERSION_MINOR) == 1
-# error "Minor version number must be defined in main CMakeLists.txt"
+/* Require major and patch version to be defined */
+#if !defined(dlite_VERSION_PATCH) || ISEMPTY(dlite_VERSION_PATCH) == 1
+# error "Patch version number must be defined in main CMakeLists.txt"
 #endif
 
 #define DLITE_CONFIG_VARS  "@DLITE_CONFIG_VARS@"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,7 +20,7 @@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
-/* Require major and patch version to be defined */
+/* Require patch version to be defined */
 #if !defined(dlite_VERSION_PATCH) || ISEMPTY(dlite_VERSION_PATCH) == 1
 # error "Patch version number must be defined in main CMakeLists.txt"
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,6 +20,14 @@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
+/* Require major and minor versions to be defined */
+#if !defined(dlite_VERSION_MAJOR) || ISEMPTY(dlite_VERSION_MAJOR) == 1
+# error "Major version number must be defined in main CMakeLists.txt"
+#endif
+#if !defined(dlite_VERSION_MINOR) || ISEMPTY(dlite_VERSION_MINOR) == 1
+# error "Minor version number must be defined in main CMakeLists.txt"
+#endif
+
 #define DLITE_CONFIG_VARS  "@DLITE_CONFIG_VARS@"
 
 /* Installation root */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -14,6 +14,12 @@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
+/* Seems that latest cmake doesn't define dlite_VERSION_PATCH by default */
+#ifndef dlite_VERSION_PATCH
+# define dlite_VERSION_PATCH 0
+#endif
+
+
 #define DLITE_CONFIG_VARS  "@DLITE_CONFIG_VARS@"
 
 /* Installation root */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,9 +20,11 @@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
-/* Require patch version to be defined */
-#if !defined(dlite_VERSION_PATCH) || ISEMPTY(dlite_VERSION_PATCH) == 1
-# error "Patch version number must be defined in main CMakeLists.txt"
+/* Require all version components to be defined */
+#if !defined(dlite_VERSION_MAJOR) || ISEMPTY(dlite_VERSION_MAJOR) == 1 || \
+    !defined(dlite_VERSION_MINOR) || ISEMPTY(dlite_VERSION_MINOR) == 1 || \
+    !defined(dlite_VERSION_PATCH) || ISEMPTY(dlite_VERSION_PATCH) == 1
+# error "All version components must be defined in main CMakeLists.txt"
 #endif
 
 #define DLITE_CONFIG_VARS  "@DLITE_CONFIG_VARS@"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,15 +20,6 @@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
-/* Seems that latest cmake defines dlite_VERSION_PATCH as empty */
-#ifndef dlite_VERSION_PATCH
-# define dlite_VERSION_PATCH 0
-#elif ISEMPTY(dlite_VERSION_PATCH) == 1
-# undef dlite_VERSION_PATCH
-# define dlite_VERSION_PATCH 0
-#endif
-
-
 #define DLITE_CONFIG_VARS  "@DLITE_CONFIG_VARS@"
 
 /* Installation root */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -8,14 +8,22 @@
 #endif
 //#include "config-paths.h"
 
+/* Macro magic to expand defined variables to 1 */
+#define DO_ISEMPTY(VAL)  VAL ## 1
+#define ISEMPTY(VAL)     DO_ISEMPTY(VAL)
+
+
 /* dlite version */
 #define dlite_VERSION "@dlite_VERSION@"
 #define dlite_VERSION_MAJOR @dlite_VERSION_MAJOR@
 #define dlite_VERSION_MINOR @dlite_VERSION_MINOR@
 #define dlite_VERSION_PATCH @dlite_VERSION_PATCH@
 
-/* Seems that latest cmake doesn't define dlite_VERSION_PATCH by default */
+/* Seems that latest cmake defines dlite_VERSION_PATCH as empty */
 #ifndef dlite_VERSION_PATCH
+# define dlite_VERSION_PATCH 0
+#elif ISEMPTY(dlite_VERSION_PATCH) == 1
+# undef dlite_VERSION_PATCH
 # define dlite_VERSION_PATCH 0
 #endif
 

--- a/src/dlite-codegen.c
+++ b/src/dlite-codegen.c
@@ -7,6 +7,7 @@
 #include "utils/tgen.h"
 #include "utils/fileutils.h"
 
+#include "config.h"
 #include "config-paths.h"
 
 #include "dlite.h"

--- a/src/dlite-codegen.c
+++ b/src/dlite-codegen.c
@@ -351,9 +351,7 @@ int dlite_instance_subs(TGenSubs *subs, const DLiteInstance *inst)
   tgen_subs_set(subs, "dlite.version", dlite_VERSION, NULL);
   tgen_subs_set_fmt(subs, "dlite.version.major",NULL,"%d",dlite_VERSION_MAJOR);
   tgen_subs_set_fmt(subs, "dlite.version.minor",NULL,"%d",dlite_VERSION_MINOR);
-#if defined(dlite_VERSION_PATCH) && ISEMPTY(dlite_VERSION_PATCH) != 1
   tgen_subs_set_fmt(subs, "dlite.version.patch",NULL,"%d",dlite_VERSION_PATCH);
-#endif
 
   /* Determine what this data is */
   if (dlite_meta_is_metameta(meta)) {

--- a/src/dlite-codegen.c
+++ b/src/dlite-codegen.c
@@ -351,7 +351,9 @@ int dlite_instance_subs(TGenSubs *subs, const DLiteInstance *inst)
   tgen_subs_set(subs, "dlite.version", dlite_VERSION, NULL);
   tgen_subs_set_fmt(subs, "dlite.version.major",NULL,"%d",dlite_VERSION_MAJOR);
   tgen_subs_set_fmt(subs, "dlite.version.minor",NULL,"%d",dlite_VERSION_MINOR);
+#if defined(dlite_VERSION_PATCH) && ISEMPTY(dlite_VERSION_PATCH) != 1
   tgen_subs_set_fmt(subs, "dlite.version.patch",NULL,"%d",dlite_VERSION_PATCH);
+#endif
 
   /* Determine what this data is */
   if (dlite_meta_is_metameta(meta)) {


### PR DESCRIPTION
Added workaround for new version of cmake not defining `<project>_VERSION_PATCH`.

Seems to be a bug in cmake - according to the documentation `<project>_VERSION_PATCH`  should be defined: 
https://cmake.org/cmake/help/latest/command/project.html?highlight=project


## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [x] Is the change limited to one issue?
- [x] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
