### PR TITLE
Pin psycopg2-binary to v2.9.5

### DIFF
--- a/.github/workflows/cd_docs.yml
+++ b/.github/workflows/cd_docs.yml
@@ -51,8 +51,9 @@ jobs:
             python3-pip \
             python3-dev \
             python3-numpy \
-            python3-yaml \
-            python3-psycopg2
+            python3-yaml
+            # python3-psycopg2
+          python3 -m pip install psycopg2-binary==2.9.5
 
       - name: Install Python dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ RUN pip install --upgrade pip \
     --trusted-host files.pythonhosted.org \
     numpy \
     PyYAML \
-    psycopg2-binary
+    psycopg2-binary==2.9.5
 
 WORKDIR /home/user
 ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/python/setup.py
+++ b/python/setup.py
@@ -159,7 +159,7 @@ class CMakeBuildExt(build_ext):
 extra_requirements = [
     "fortran-language-server",
     "PyYAML",
-    #"psycopg2-binary",
+    "psycopg2-binary==2.9.5",
     "pandas",
     "pymongo",
     "rdflib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 fortran-language-server
 numpy
 PyYAML
-# psycopg2-binary leads to segfault - comment it out for now...
-#psycopg2-binary
+# psycopg2-binary can lead to segfault - so far all seems good with v2.9.5
+psycopg2-binary==2.9.5
 pandas
 rdflib
 pint


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
According to SINTEF/oteapi-optimade#117 and EMMC-ASBL/oteapi-dlite#129, using psycopg2-binary v2.9.5 seems to work fine.

Fixes #527 by pinning psycopg2-binary to v2.9.5.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
