### PR TITLE
Quickfix for assertion error in dlite_json_asprint()

### DIFF
--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -287,7 +287,7 @@ int dlite_json_sprint(char *dest, size_t size, const DLiteInstance *inst,
   reallocated and `*size` updated to the new buffer size.
 
   If `pos` is larger than `*size` the bytes at index `i` are
-  initialized to space ( ), where ``*size <= i < pos``.
+  initialized to space (' '), where ``*size <= i < pos``.
 
   Returns number or bytes written (not including terminating NUL) or a
   negative number on error.

--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -297,7 +297,7 @@ int dlite_json_asprint(char **dest, size_t *size, size_t pos,
                        DLiteJsonFlag flags)
 {
   int m;
-  void *q;
+  char *q;
   size_t newsize;
 
   if (!dest || !*dest || !*size) {
@@ -326,7 +326,7 @@ int dlite_json_asprint(char **dest, size_t *size, size_t pos,
   /* Write */
   m = dlite_json_sprint(q + pos, PDIFF(newsize, pos), inst, indent, flags);
   if (m < 0) return m;
-  assert(m+pos < (int)newsize);
+  assert(m+pos < newsize);
 
   /* On success, update `*dest` and `*size` */
   *dest = q;

--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -292,17 +292,24 @@ int dlite_json_asprint(char **dest, size_t *size, size_t pos,
   int m;
   void *q;
   size_t newsize;
-  if (!dest && !*dest) *size = 0;
-  m = dlite_json_sprint(*dest + pos, PDIFF(*size, pos), inst, indent, flags);
+  if (!dest && !*dest) {
+    *size = 0;
+    m = dlite_json_sprint(*dest, 0, inst, indent, flags);
+    if (m > 0) m += pos;
+  } else {
+    m = dlite_json_sprint(*dest + pos, PDIFF(*size, pos), inst, indent, flags);
+  }
   if (m < 0) return m;
   if (m < (int)PDIFF(*size, pos)) return m;
 
   /* Reallocate buffer to required size. */
-  newsize = m + pos + 1;
+  newsize = m + pos + 2;
   if (!(q = realloc(*dest, newsize))) return -1;
   *dest = q;
   *size = newsize;
+
   m = dlite_json_sprint(*dest + pos, PDIFF(*size, pos), inst, indent, flags);
+  if (m < 0) return m;
   assert(0 <= m && m < (int)*size);
   return m;
 }

--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -303,6 +303,8 @@ int dlite_json_asprint(char **dest, size_t *size, size_t pos,
   if (m < (int)PDIFF(*size, pos)) return m;
 
   /* Reallocate buffer to required size. */
+  // FIXME: newsize sould really be `newsize = m + pos + 1;`.
+  // dlite_json_sprint() seems to report one byte too little when called with size=0.
   newsize = m + pos + 2;
   if (!(q = realloc(*dest, newsize))) return -1;
   *dest = q;

--- a/src/dlite-json.h
+++ b/src/dlite-json.h
@@ -62,7 +62,7 @@ int dlite_json_sprint(char *dest, size_t size, const DLiteInstance *inst,
   reallocated and `*size` updated to the new buffer size.
 
   If `pos` is larger than `*size` the bytes at index `i` are
-  initialized to NUL, where ``*size <= i < pos``.
+  initialized to space (' '), where ``*size <= i < pos``.
 
   Returns number or bytes written (not including terminating NUL) or a
   negative number on error.

--- a/src/dlite-json.h
+++ b/src/dlite-json.h
@@ -53,12 +53,19 @@ int dlite_json_sprint(char *dest, size_t size, const DLiteInstance *inst,
                       int indent, DLiteJsonFlag flags);
 
 /**
-  Like dlite_sprint(), but prints to allocated buffer.
+  Like dlite_json_sprint(), but prints to allocated buffer.
 
   Prints to position `pos` in `*dest`, which should point to a buffer
-  of size `*size`.  `*dest` is reallocated if needed.
+  of size `*size`. Bytes at position less than `pos` are not changed.
 
-  Returns number or bytes written or a negative number on error.
+  If `*dest` is NULL or `*size` is less than needed, `*dest` is
+  reallocated and `*size` updated to the new buffer size.
+
+  If `pos` is larger than `*size` the bytes at index `i` are
+  initialized to NUL, where ``*size <= i < pos``.
+
+  Returns number or bytes written (not including terminating NUL) or a
+  negative number on error.
  */
 int dlite_json_asprint(char **dest, size_t *size, size_t pos,
                        const DLiteInstance *inst, int indent,

--- a/src/tests/test_json.c
+++ b/src/tests/test_json.c
@@ -57,6 +57,11 @@ MU_TEST(test_sprint)
   //printf("%s\n", buf);
   mu_assert_int_eq(404, m);
 
+  m = dlite_json_sprint(buf, sizeof(buf), inst, 0, 0);
+  //printf("\n--------------------------------------------------------\n");
+  //printf("<%.*s>\n", m, buf);
+  mu_assert_int_eq(415, m);
+
 
 
   /* soft5 format: dliteJsonArrays set */
@@ -73,6 +78,15 @@ MU_TEST(test_sprint)
   mu_assert_int_eq(1165, m);
 
   //printf("\n========================================================\n");
+
+
+  /* Tests for PR #541 */
+  m = dlite_json_sprint(buf, 0, inst, 4, dliteJsonSingle);
+  mu_assert_int_eq(404, m);
+
+  m = dlite_json_sprint(NULL, 0, inst, 4, dliteJsonSingle);
+  mu_assert_int_eq(404, m);
+
 }
 
 


### PR DESCRIPTION
# Description:
Added one more byte to the allocated buffer than expected, which seems to fix the assertion. Requireing this extra byte is unexpected. It seems to be caused by dlite_json_sprint() reporting one byte too little when called with size=0 for a collection with relations! Please add a new issue about this.

Updated documentation and made the implementation of dlite_json_asprint() little more rigorous.
Added two more tests for dlite_json_sprint().

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
