### PR TITLE
Added script that patches virtual environment activate script

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -233,7 +233,17 @@ install(
   PATTERN ".gitignore" EXCLUDE
   PATTERN "*~" EXCLUDE
 )
-
+if(DEFINED ENV{VIRTUAL_ENV})
+  find_program(BASH bash)
+  find_program(PATCH patch)
+  install(
+    CODE "execute_process(COMMAND ${BASH} ${dlite_SOURCE_DIR}/cmake/patch-activate.sh)"
+  )
+  install(
+    PROGRAMS ${dlite_SOURCE_DIR}/cmake/patch-activate.sh
+    TYPE BIN
+  )
+endif()
 
 add_subdirectory(scripts)
 

--- a/cmake/patch-activate.sh
+++ b/cmake/patch-activate.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Patch virtualenv activate script to support LD_LIBRARY_PATH
+#
+
+if [ -z "$VIRTUAL_ENV" ]; then
+   echo "Not in a virtual environment" >&2
+   exit 1
+fi
+
+cd $VIRTUAL_ENV/bin
+
+patch -u -f -F 1 <<EOF
+--- activate    2023-06-18 20:37:58.486341271 +0200
++++ activate.diff       2023-06-18 21:51:48.895940777 +0200
+@@ -17,6 +17,11 @@
+         export PATH
+         unset _OLD_VIRTUAL_PATH
+     fi
++    if ! [ -z "\${_OLD_VIRTUAL_LD_LIBRARY_PATH+_}" ] ; then
++        LD_LIBRARY_PATH="\$_OLD_VIRTUAL_LD_LIBRARY_PATH"
++        export LD_LIBRARY_PATH
++        unset _OLD_VIRTUAL_LD_LIBRARY_PATH
++    fi
+     if ! [ -z "\${_OLD_VIRTUAL_PYTHONHOME+_}" ] ; then
+         PYTHONHOME="\$_OLD_VIRTUAL_PYTHONHOME"
+         export PYTHONHOME
+@@ -54,6 +59,10 @@
+ PATH="\$VIRTUAL_ENV/bin:\$PATH"
+ export PATH
+
++_OLD_VIRTUAL_LD_LIBRARY_PATH="\$LD_LIBRARY_PATH"
++LD_LIBRARY_PATH="\$VIRTUAL_ENV/lib:\$LD_LIBRARY_PATH"
++export LD_LIBRARY_PATH
++
+ # unset PYTHONHOME if set
+ if ! [ -z "\${PYTHONHOME+_}" ] ; then
+     _OLD_VIRTUAL_PYTHONHOME="\$PYTHONHOME"
+EOF
+
+exit $?

--- a/python/setup.py
+++ b/python/setup.py
@@ -221,6 +221,7 @@ setup(
             str(Path(".") / "bin" / "dlite-getuuid"),
             str(Path(".") / "bin" / "dlite-codegen"),
             str(Path(".") / "bin" / "dlite-env"),
+            str(Path(".") / "bin" / "patch-activate.sh"),
         ]
     },
     ext_modules=[

--- a/storages/python/tests-python/CMakeLists.txt
+++ b/storages/python/tests-python/CMakeLists.txt
@@ -7,7 +7,6 @@ set(python-tests
   test_yaml_storage_python
   test_mongodb_python
   test_mongodb-atlas_python
-  test_redis
   )
 
 include(FindPythonModule)

--- a/storages/python/tests-python/CMakeLists.txt
+++ b/storages/python/tests-python/CMakeLists.txt
@@ -7,6 +7,7 @@ set(python-tests
   test_yaml_storage_python
   test_mongodb_python
   test_mongodb-atlas_python
+  test_redis
   )
 
 include(FindPythonModule)


### PR DESCRIPTION
 Description
 ===========
Added a `patch-activate.sh` script that patches the virtual environment activate script on POSIX systems such that LD_LIBRARY_PATH is set correctly.

Forgetting to set LD_LIBRARY_PATH has led to many bugs and issues...

Closes #540

Type of change
--------------
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Test update

Checklist for the reviewer
--------------------------
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
