### PR TITLE
Convince redis to not hang

### DIFF
--- a/storages/python/python-storage-plugins/redis.py
+++ b/storages/python/python-storage-plugins/redis.py
@@ -17,7 +17,10 @@ class redis(dlite.DLiteStorageBase):
             - `port`: Port to connect to (default: 6379).
             - `username`: Redis user name.
             - `password`: Redis password.
-            - `ssl`: Whether to ssl-encrypt the connection (default: false).
+            - `socket_keepalive`: Whether to enable socket keepalive option.
+              Seems to protect against hanging.  Default: true
+            - `socket_timeout`: Timeout after given number of seconds.
+            - `ssl`: Whether to ssl-encrypt the connection.
             - `ssl_certfile`: Path to SSL certificate signing request (.crt).
             - `ssl_keyfile`: Path to SSL private key file (.key).
             - `ssl_ca_certs`: Path to SSL certificate container (.pem).
@@ -31,7 +34,7 @@ class redis(dlite.DLiteStorageBase):
               Generate the key with `crystallography.fernet.generate_key()`.
         """
         self.uri = uri
-        opts = Options(options, defaults="port=6379;ssl=false;db=0")
+        opts = Options(options, defaults="port=6379;socket_keepalive=true;db=0")
 
         # Pop out options passed to redis.set()
         self.setopts = {
@@ -45,7 +48,11 @@ class redis(dlite.DLiteStorageBase):
 
         # Fix option types and open Redis connection
         opts.port = int(opts.port)
-        opts.ssl = dlite.asbool(opts.ssl)
+        opts.socket_keepalive = dlite.asbool(opts.socket_keepalive)
+        if "socket_timeout" in opts:
+            opts.socket_timeout = int(opts.socket_timeout)
+        if "ssl" in opts:
+            opts.ssl = dlite.asbool(opts.ssl)
         opts.db = int(opts.db)
         self.redis = Redis(host=uri, **opts)
         self.closed = False

--- a/storages/python/tests-python/test_redis.py
+++ b/storages/python/tests-python/test_redis.py
@@ -27,7 +27,7 @@ save2 = inst2.asdict()
 
 
 # Test storing to Redis
-with dlite.Storage("redis", "localhost", "port=6379;expire=1;db=13") as s:
+with dlite.Storage("redis", "localhost", "expire=1;db=13") as s:
     try:
         s.save(inst1)
     except dlite.DLiteError as exc:


### PR DESCRIPTION
 Description
 ===========
Added `socket_keepalive` option and enabled it by default - this seems to counteract that the redis client hangs indefinitely.

Type of change
--------------
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

Checklist for the reviewer
--------------------------
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
