### PR TITLE
Improved error reporting

### DIFF
--- a/bindings/python/scripts/dlite-validate
+++ b/bindings/python/scripts/dlite-validate
@@ -5,7 +5,6 @@ import sys
 import argparse
 import json
 import re
-import yaml
 from pathlib import Path
 
 import dlite
@@ -45,8 +44,12 @@ def parse(url, driver=None, options=None, id=None):
             with open(path, 'rt') as f:
                 return dlite.Instance.from_dict(json.load(f), id=id)
         elif fileext in ('yaml', 'yml'):
+            # Import yaml only if needed, to avoid creating an extra dependency
+            import yaml
+
             with open(path, 'rt') as f:
                 return dlite.Instance.from_dict(yaml.safe_load(f), id=id)
+
         return dlite.Instance.from_location(fileext, path, options=options)
 
 

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -121,8 +121,12 @@ const DLiteStoragePlugin *dlite_storage_plugin_get(const char *name)
       plugin_load_all(info);
       memcpy(g->storage_plugin_path_hash, hash, sizeof(hash));
 
-      if ((api = (const DLiteStoragePlugin *)plugin_get_api(info, name)))
-        return api;
+     ErrTry:  // silence errors
+      api = (const DLiteStoragePlugin *)plugin_get_api(info, name);
+     ErrOther:  // update plugins.c to produce more specific errors
+      break;
+     ErrEnd;
+      if (api) return api;
     }
   }
 

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -145,7 +145,8 @@ const DLiteStoragePlugin *dlite_storage_plugin_get(const char *name)
       if (r >= 0) m += r;
     }
     if (n <= 1)
-      m += asnpprintf(&buf, &size, m, "Are the %sDLITE_STORAGE_PLUGIN_DIRS "
+      m += asnpprintf(&buf, &size, m, "Are the required Python packages "
+                      "installed or %sDLITE_STORAGE_PLUGIN_DIRS "
                       "or DLITE_PYTHON_STORAGE_PLUGIN_DIRS "
                       "environment variables set?", submsg);
     errx(1, "%s", buf);

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -106,8 +106,12 @@ const DLiteStoragePlugin *dlite_storage_plugin_get(const char *name)
   if (!(info = get_storage_plugin_info())) return NULL;
 
   /* Return plugin if it is loaded */
-  if ((api = (const DLiteStoragePlugin *)plugin_get_api(info, name)))
-    return api;
+ ErrTry:  // silence errors
+  api = (const DLiteStoragePlugin *)plugin_get_api(info, name);
+ ErrOther:  // hmm, we should update plugins.c to produce more specific errors
+  break;
+ ErrEnd;
+  if (api) return api;
 
   /* ...otherwise, if any plugin path has changed, reload all plugins
      and try again */

--- a/src/pyembed/CMakeLists.txt
+++ b/src/pyembed/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 set(pyembed_sources
   pyembed/dlite-pyembed.c
+  pyembed/dlite-pyembed-utils.c
   pyembed/dlite-python-singletons.c
   pyembed/dlite-python-storage.c
   pyembed/dlite-python-mapping.c

--- a/src/pyembed/dlite-pyembed-utils.c
+++ b/src/pyembed/dlite-pyembed-utils.c
@@ -10,11 +10,19 @@
 */
 int dlite_pyembed_has_module(const char *module_name)
 {
+  PyObject *name, *module, *type, *value, *tb;
+
   dlite_pyembed_initialise();
 
-  // PyImport_AddModule() returns a borrowed reference, so it is safe to
-  // discard its return value.
-  if (PyImport_AddModule(module_name) == 0) return 1;
-  PyErr_Clear();
-  return 0;
+  if (!(name = PyUnicode_FromString(module_name)))
+    return dlite_err(1, "invalid string: '%s'", module_name), 0;
+
+  PyErr_Fetch(&type, &value, &tb);
+  module = PyImport_Import(name);
+  PyErr_Restore(type, value, tb);
+
+  Py_DECREF(name);
+  if (!module) return 0;
+  Py_DECREF(module);
+  return 1;
 }

--- a/src/pyembed/dlite-pyembed-utils.c
+++ b/src/pyembed/dlite-pyembed-utils.c
@@ -1,0 +1,20 @@
+#include <Python.h>
+#include "dlite-pyembed.h"
+
+
+/*
+  Returns non-zero if the given Python module is available.
+
+  A side effect of calling this function is that the module will
+  be imported if it is available.
+*/
+int dlite_pyembed_has_module(const char *module_name)
+{
+  dlite_pyembed_initialise();
+
+  // PyImport_AddModule() returns a borrowed reference, so it is safe to
+  // discard its return value.
+  if (PyImport_AddModule(module_name) == 0) return 1;
+  PyErr_Clear();
+  return 0;
+}

--- a/src/pyembed/dlite-pyembed-utils.h
+++ b/src/pyembed/dlite-pyembed-utils.h
@@ -1,0 +1,22 @@
+#ifndef _DLITE_PYEMBED_UTILS_H
+#define _DLITE_PYEMBED_UTILS_H
+
+/**
+  @file
+  @brief Utility functions for embedding Python
+
+  This header will not import Python.h, making it safe to import from
+  code that also imports config.h.
+ */
+
+
+/**
+  Returns non-zero if the given Python module is available.
+
+  A side effect of calling this function is that the module will
+  be imported if it is available.
+ */
+int dlite_pyembed_has_module(const char *module_name);
+
+
+#endif /* _DLITE_PYEMBED_UTILS_H */

--- a/src/pyembed/dlite-pyembed.c
+++ b/src/pyembed/dlite-pyembed.c
@@ -160,7 +160,6 @@ int dlite_pyembed_verr(int eval, const char *msg, va_list ap)
     errmsg[0] = '\0';
     PyErr_Fetch(&type, &value, &tb);
     PyErr_NormalizeException(&type, &value, &tb);
-    PyException_SetTraceback(value, tb);
     assert(type && value);
 
     /* If the DLITE_PYDEBUG environment variable is set, print full Python

--- a/src/pyembed/dlite-pyembed.c
+++ b/src/pyembed/dlite-pyembed.c
@@ -160,6 +160,7 @@ int dlite_pyembed_verr(int eval, const char *msg, va_list ap)
     errmsg[0] = '\0';
     PyErr_Fetch(&type, &value, &tb);
     PyErr_NormalizeException(&type, &value, &tb);
+    PyException_SetTraceback(value, tb);
     assert(type && value);
 
     /* If the DLITE_PYDEBUG environment variable is set, print full Python
@@ -172,6 +173,7 @@ int dlite_pyembed_verr(int eval, const char *msg, va_list ap)
       PySys_WriteStderr("\n");
       PyErr_Print();
       PySys_WriteStderr("\n");
+      PyErr_Clear();
    }
 
     /* Try to get traceback info from traceback.format_exception()... */
@@ -410,15 +412,22 @@ DLiteInstance *dlite_pyembed_get_instance(PyObject *pyinst)
   A Python plugin is a subclass of `baseclass` that implements the
   expected functionality.
 
+  `*failed_paths` is a NULL-terminated array of pointers to paths to
+  plugins that failed to load.
+  `*failed_len` is the allocated length of `*failed_paths`.
+
   Returns NULL on error.
  */
-PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass)
+PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass,
+                                     const char ***failed_paths,
+                                     size_t *failed_len)
 {
   const char *path;
   PyObject *main_dict, *ppath=NULL, *pfun=NULL, *subclasses=NULL, *lst=NULL;
   PyObject *subclassnames=NULL;
   FUIter *iter;
-  int i;
+  int i, pos=0;
+  char errors[4098] = "";
 
   dlite_errclr();
   dlite_pyembed_initialise();
@@ -456,18 +465,67 @@ PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass)
     if (stat) FAIL("cannot assign path to '__file__' in dict of main module");
 
     if ((basename = fu_basename(path))) {
-      if ((fp = fopen(path, "r"))) {
-        PyObject *ret = PyRun_File(fp, basename, Py_file_input, main_dict,
-                                   main_dict);
-        if (!ret) dlite_pyembed_err(1, "error parsing '%s'", path);
-        Py_XDECREF(ret);
-        fclose(fp);
+      size_t n;
+      const char **q = (failed_paths) ? *failed_paths : NULL;
+      for (n=0; q && *q; n++)
+        if (strcmp(*(q++), path) == 0) break;
+      int in_failed = (q && *q) ? 1 : 0;  // whether loading path has failed
+
+      if (!in_failed) {
+        if ((fp = fopen(path, "r"))) {
+          PyObject *ret = PyRun_File(fp, basename, Py_file_input, main_dict,
+                                     main_dict);
+          if (!ret) {
+            size_t chunklen = 20;  // allocation chunk length
+            if (!*failed_paths) {
+              *failed_len = chunklen;
+              q = *failed_paths = calloc(*failed_len, sizeof(char *));
+            } else if (n >= *failed_len - 1) {
+              char **p;
+              size_t len = *failed_len;
+              *failed_len += chunklen;
+              if (!(p = realloc(*failed_paths, *failed_len*sizeof(char *))))
+                FAIL("allocation failure");
+              memset(p + len, 0, chunklen*sizeof(char *));
+              *failed_paths = (const char **)p;
+            }
+            *q = strdup(path);
+            (*failed_len)++;
+
+            PyObject *type=NULL, *value=NULL, *tb=NULL, *name=NULL, *msg=NULL;
+            PyErr_Fetch(&type, &value, &tb);
+            int showtb = tb && tb != Py_None && getenv("DLITE_PYDEBUG");
+            name = PyObject_GetAttrString(type, "__name__");
+            msg = PyObject_Str(value);
+            int m = snprintf(errors+pos, sizeof(errors)-pos,
+                             "   - %s: %s: %s%s%s\n",
+                             path,
+                             PyUnicode_AsUTF8(name),
+                             PyUnicode_AsUTF8(msg),
+                             (showtb) ? "\n": "",
+                             (showtb) ? PyUnicode_AsUTF8(tb) : "");
+            if (m > 0) pos += m;
+            Py_XDECREF(type);
+            Py_XDECREF(value);
+            Py_XDECREF(tb);
+            Py_XDECREF(name);
+            Py_XDECREF(msg);
+            fclose(fp);
+          }
+          Py_XDECREF(ret);
+        }
       }
       free(basename);
     }
 
   }
   if (fu_pathsiter_deinit(iter)) goto fail;
+
+  if (errors[0])
+    dlite_warn("Could not load the following Python plugins:\n%s"
+               "   You might have to install corresponding python "
+               "package(s).\n",
+               errors);
 
   /* Append new subclasses to the list of Python plugins that will be
      returned */

--- a/src/pyembed/dlite-pyembed.h
+++ b/src/pyembed/dlite-pyembed.h
@@ -99,9 +99,7 @@ DLiteInstance *dlite_pyembed_get_instance(PyObject *pyinst);
   Returns NULL on error.
  */
 PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass,
-                                     const char ***failed_paths,
-                                     size_t *failed_len);
-
+                                     char ***failed_paths, size_t *failed_len);
 
 
 #endif /* _DLITE_PYEMBED_H */

--- a/src/pyembed/dlite-pyembed.h
+++ b/src/pyembed/dlite-pyembed.h
@@ -104,9 +104,15 @@ DLiteInstance *dlite_pyembed_get_instance(PyObject *pyinst);
   A Python plugin is a subclass of `baseclassname` that implements the
   expected functionality.
 
+  `*failed_paths` is a NULL-terminated array of pointers to paths to
+  plugins that failed to load.
+  `*failed_len` is the allocated length of `*failed_paths`.
+
   Returns NULL on error.
  */
-PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass);
+PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass,
+                                     const char ***failed_paths,
+                                     size_t *failed_len);
 
 
 #endif /* _DLITE_PYEMBED_H */

--- a/src/pyembed/dlite-pyembed.h
+++ b/src/pyembed/dlite-pyembed.h
@@ -18,18 +18,6 @@
 #include "utils/plugin.h"
 #include "dlite.h"
 
-/* Declarations from utils/fileutils.h - this file cannot be included because
-   of conflicts with Python.h */
-/*
-typedef struct _FUPaths FUPaths;
-typedef struct _FUIter FUIter;
-typedef struct _PluginInfo PluginInfo;
-FUIter *fu_startmatch(const char *pattern, const FUPaths *paths);
-const char *fu_nextmatch(FUIter *iter);
-int fu_endmatch(FUIter *iter);
-*/
-
-
 
 /**
   Initialises the embedded Python environment.
@@ -113,6 +101,7 @@ DLiteInstance *dlite_pyembed_get_instance(PyObject *pyinst);
 PyObject *dlite_pyembed_load_plugins(FUPaths *paths, PyObject *baseclass,
                                      const char ***failed_paths,
                                      size_t *failed_len);
+
 
 
 #endif /* _DLITE_PYEMBED_H */

--- a/src/pyembed/dlite-python-mapping.c
+++ b/src/pyembed/dlite-python-mapping.c
@@ -33,8 +33,10 @@ typedef struct {
   FUPaths mapping_paths;
   int mapping_paths_initialised;
   unsigned char mapping_plugin_path_hash[32];
-
   PyObject *loaded_mappings;  /* A cache with all loaded plugins */
+  const char **failed_paths;  /* NULL-terminated array of paths to storages
+                                 that fail to load. */
+  size_t failed_len;          /* Allocated length of `failed_paths`. */
 } Globals;
 
 
@@ -192,7 +194,9 @@ void *dlite_python_mapping_load(void)
              sizeof(g->mapping_plugin_path_hash)) != 0) {
     if (g->loaded_mappings) dlite_python_mapping_unload();
     g->loaded_mappings = dlite_pyembed_load_plugins((FUPaths *)paths,
-                                                    mappingbase);
+                                                    mappingbase,
+                                                    &g->failed_paths,
+                                                    &g->failed_len);
     memcpy(g->mapping_plugin_path_hash, hash,
            sizeof(g->mapping_plugin_path_hash));
   }

--- a/src/pyembed/dlite-python-storage.c
+++ b/src/pyembed/dlite-python-storage.c
@@ -10,6 +10,7 @@
 
 #include "config-paths.h"
 
+#include "utils/strutils.h"
 #include "dlite.h"
 #include "dlite-macros.h"
 #include "dlite-misc.h"
@@ -31,7 +32,7 @@ typedef struct {
   int initialised;            /* Whether `paths` is initiated */
   int modified;               /* Whether `paths` is modified */
   PyObject *loaded_storages;  /* Cache with all loaded python storage plugins */
-  const char **failed_paths;  /* NULL-terminated array of paths to storages
+  char **failed_paths;        /* NULL-terminated array of paths to storages
                                  that fail to load. */
   size_t failed_len;          /* Allocated length of `failed_paths`. */
 } PythonStorageGlobals;
@@ -44,13 +45,14 @@ static void free_globals(void *globals)
   if (g->initialised) fu_paths_deinit(&g->paths);
 
   /* Do not call Py_DECREF if we are in an atexit handler */
-  if (!dlite_globals_in_atexit()) Py_XDECREF(g->loaded_storages);
-
-  if (g->failed_paths) {
-    const char **p = g->failed_paths;
-    while (*p) free((char *)*(p++));
-    free(g->failed_paths);
+  if (!dlite_globals_in_atexit()) {
+    Py_XDECREF(g->loaded_storages);
+    g->loaded_storages = NULL;
   }
+
+  if (g->failed_paths) strlst_free(g->failed_paths);
+  g->failed_paths = NULL;
+  g->failed_len = 0;
   free(g);
 }
 

--- a/src/tests/python/test_pyembed.c
+++ b/src/tests/python/test_pyembed.c
@@ -28,7 +28,7 @@ MU_TEST(test_load_modules)
   fu_paths_init(&paths, "DLITE_PYTHON_MAPPING_PLUGIN_DIRS");
   fu_paths_insert(&paths, STRINGIFY(TESTDIR), 0);
 
-  plugins = dlite_pyembed_load_plugins(&paths, mappingbase);
+  plugins = dlite_pyembed_load_plugins(&paths, mappingbase, NULL, NULL);
   mu_check(plugins);
   mu_check(PyList_Check(plugins));
 

--- a/src/utils/strutils.h
+++ b/src/utils/strutils.h
@@ -1,9 +1,13 @@
 /* strutils.h -- cross-platform string utility functions
  *
- * Copyright (C) 2021 SINTEF
+ * Copyright (C) 2021-2023 SINTEF
  *
  * Distributed under terms of the MIT license.
  */
+/**
+  @file
+  @brief Cross-platform string utility functions
+*/
 #ifndef _STRUTILS_H
 #define _STRUTILS_H
 
@@ -14,6 +18,10 @@
 # define __attribute__(x)
 #endif
 
+/**
+ * @name Typedefs and structs
+ */
+/** @{ */
 
 /** Flags for strquote() */
 typedef enum _StrquoteFlags {
@@ -42,13 +50,24 @@ typedef enum {
 } StrCategory;
 
 
+/** @} */
 /**
-  A convinient variant of asnprintf() that returns the allocated string,
+ * @name Print allocated string
+ */
+/** @{ */
+
+/**
+  A convinient variant of asprintf() that returns the allocated string,
   or NULL on error.
  */
 char *aprintf(const char *fmt, ...)
   __attribute__ ((__malloc__, __format__ (__printf__, 1, 2)));
 
+/** @} */
+/**
+ * @name Functions for writing characters to a buffer
+ */
+/** @{ */
 
 /**
   Writes character `c` to buffer `dest` of size `size`.  If there is
@@ -101,7 +120,6 @@ int strput(char **destp, size_t *sizep, size_t pos, const char *src);
  */
 int strnput(char **destp, size_t *sizep, size_t pos, const char *src, int n);
 
-
 /**
   Like strnput(), but escapes all characters in categories larger than
   `unescaped`, which should be less than `strcatOther`.
@@ -115,6 +133,12 @@ int strnput_escape(char **destp, size_t *sizep, size_t pos,
                    const char *src, int len,
                    StrCategory unescaped, const char *escape);
 
+
+/** @} */
+/**
+ * @name Quoting/unquoting strings
+ */
+/** @{ */
 
 /**
   Double-quote input string `s` and write it to `dest`.
@@ -166,6 +190,12 @@ int strnunquote(char *dest, size_t size, const char *s, int n,
                int *consumed, StrquoteFlags flags);
 
 
+/** @} */
+/**
+ * @name Hexadecimal encoding/decoding
+ */
+/** @{ */
+
 /**
   Writes binary data to hex-encoded string.
 
@@ -199,6 +229,13 @@ int strhex_decode(unsigned char *data, size_t size, const char *hex,
                   int hexsize);
 
 
+/** @} */
+/**
+ * @name Character categorisation
+ */
+/** @{ */
+
+
 /**
   Returns the category of character `c`.
  */
@@ -228,5 +265,75 @@ int strcatjspn(const char *s, StrCategory cat);
  */
 int strcatcjspn(const char *s, StrCategory cat);
 
+
+/** @} */
+/**
+ * @name Allocated string list
+ *
+ * A string list is an allocated NULL-terminated array of pointers to
+ * allocated strings.
+ */
+/** @{ */
+
+/**
+  Insert string `s` before position `i` in NULL-terminated array of
+  string pointers `strlst`.
+
+  If `i` is negative count from the end of the string, like Python.
+  Any `i` out of range correspond to appending.
+
+  `n` is the allocated length of `strlst`.  If needed `strlst` will be
+  reallocated and `n` updated.
+
+  Returns a pointer to the new string list or NULL on allocation error.
+ */
+char **strlst_insert(char **strlst, size_t *n, const char *s, int i);
+
+/**
+  Appends string `s` to NULL-terminated array of string pointers `strlst`.
+  `n` is the allocated length of `strlst`.  If needed `strlst` will be
+  reallocated and `n` updated.
+
+  Returns a pointer to the new string list or NULL on allocation error.
+ */
+char **strlst_append(char **strlst, size_t *n, const char *s);
+
+/** Return number of elements in string list. */
+size_t strlst_count(char **strlst);
+
+/** Free all memory in string list. */
+void strlst_free(char **strlst);
+
+/**
+  Returns a pointer to element `i` the string list. Like in Python,
+  negative `i` counts from the back.
+
+  The caller gets a borrowed reference to the string. Do not free it.
+
+  Returns NULL if `i` is out of range.
+*/
+const char *strlst_get(char **strlst, int i);
+
+/**
+  Remove element `i` from the string list. Like in Python, negative `i`
+  counts from the back.
+
+  Returns non-zero if `i` is out of range.
+*/
+int strlst_remove(char **strlst, int i);
+
+/**
+  Remove and return element `i` from the string list. Like in Python,
+  negative `i` counts from the back.
+
+  The caller becomes the owner of the returned string and is
+  responsible to free it.
+
+  Returns NULL if `i` is out of range.
+*/
+char *strlst_pop(char **strlst, int i);
+
+
+/** @} */
 
 #endif  /* _STRUTILS_H */

--- a/src/utils/tests/test_bson.c
+++ b/src/utils/tests/test_bson.c
@@ -397,6 +397,7 @@ double help_issue556(double x)
 MU_TEST(test_issue556) {
   double inf = 1.0/0.0;
   double nan = 0.0/0.0;
+  /* Some interesting doubles to check... */
   double values_to_test[] = {
     1, 0, -1, 3.14, 2.73, -2.3, 1e-6, -1e-6, 1e8, -1e8,
     +0.0, -0.0, inf, -inf, nan

--- a/src/utils/tests/test_bson.c
+++ b/src/utils/tests/test_bson.c
@@ -373,26 +373,46 @@ MU_TEST(test_parse)
 }
 
 
-MU_TEST(test_scan) {
-  /* There seems to be an error in how some doubles are serialised,
-     like -1e-8 */
+
+#include <assert.h>
+
+/* Dedicated tests for issue 556 - inconsistent BSON encoding/decoding */
+
+/* Creates a BSON document containg x as its only encoded value and then
+   decode the document and return the decoded value. */
+double help_issue556(double x)
+{
   BsonError errcode;
-  unsigned char doc[1024], doc01[] =
-    "\x14\x00\x00\x00\x01value\x00\xc3\xf5(\\\x8f\xc2\x05@\x00";
+  unsigned char doc[1024];
+  int n, m, bufsize=sizeof(doc);
 
-  double value = bson_scan_double(doc01, "value", &errcode);
-  mu_assert_double_eq(2.72, value);
-
-  int i, n, m, bufsize=sizeof(doc);
-  double v = 2.72;
   n = bson_init_document(doc, bufsize);
-  m = bson_append(doc, bufsize-n, bsonDouble, "value", sizeof(double), &v);
-  mu_check(m > 0);
-  n += m;
-  mu_assert_int_eq(0x14, bson_docsize(doc));
-  mu_assert_int_eq(0x14, n);
-  for (i=0; i<n; i++)
-    mu_assert_int_eq((int)doc01[i], (int)doc[i]);
+  m = bson_append(doc, bufsize-n, bsonDouble, "value", sizeof(double), &x);
+  assert(m > 0);
+
+  double value = bson_scan_double(doc, "value", &errcode);
+  return value;
+}
+
+MU_TEST(test_issue556) {
+  double inf = 1.0/0.0;
+  double nan = 0.0/0.0;
+  double values_to_test[] = {
+    1, 0, -1, 3.14, 2.73, -2.3, 1e-6, -1e-6, 1e8, -1e8,
+    +0.0, -0.0, inf, -inf, nan
+  };
+
+  /* tests */
+  printf("\nTest double encoding/decoding:\n");
+  int i, n=sizeof(values_to_test)/sizeof(double);
+  for (i=0; i<n; i++) {
+    double x = values_to_test[i];
+    double v = help_issue556(x);
+    printf("  %8.3g..", v);
+    mu_assert_double_eq(x, v);
+    printf("  ok\n");
+  }
+  printf("\n");
 }
 
 
@@ -407,7 +427,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_subdoc);
   MU_RUN_TEST(test_append_binary);
   MU_RUN_TEST(test_parse);
-  MU_RUN_TEST(test_scan);
+  MU_RUN_TEST(test_issue556);
 }
 
 

--- a/src/utils/tests/test_strutils.c
+++ b/src/utils/tests/test_strutils.c
@@ -364,6 +364,57 @@ MU_TEST(test_strcatspn)
 }
 
 
+MU_TEST(test_strlst)
+{
+  char **strlst=NULL;
+  size_t n=0;
+
+  mu_assert_int_eq(0, strlst_count(strlst));
+
+  strlst = strlst_append(strlst, &n, "first");
+  mu_assert_int_eq(1, strlst_count(strlst));
+
+  strlst = strlst_insert(strlst, &n, "second", 1);
+  mu_assert_int_eq(2, strlst_count(strlst));
+
+  strlst = strlst_insert(strlst, &n, "insert1", 1);
+  mu_assert_int_eq(3, strlst_count(strlst));
+
+  strlst = strlst_insert(strlst, &n, "insert2", -1);
+  mu_assert_int_eq(4, strlst_count(strlst));
+
+  mu_assert_string_eq("first",   strlst[0]);
+  mu_assert_string_eq("insert1", strlst[1]);
+  mu_assert_string_eq("insert2", strlst[2]);
+  mu_assert_string_eq("second",  strlst[3]);
+  mu_assert_string_eq(NULL,      strlst[4]);
+
+  mu_assert_string_eq(strlst[0], strlst_get(strlst, 0));
+  mu_assert_string_eq(strlst[3], strlst_get(strlst, 3));
+  mu_assert_string_eq(strlst[3], strlst_get(strlst, -1));
+  mu_assert_string_eq(NULL,      strlst_get(strlst, 4));
+  mu_assert_string_eq(strlst[0], strlst_get(strlst, -4));
+  mu_assert_string_eq(NULL,      strlst_get(strlst, -5));
+
+  char *s = strlst_pop(strlst, -2);
+  mu_assert_string_eq("insert2", s);
+  mu_assert_int_eq(3, strlst_count(strlst));
+  free(s);
+
+  mu_assert_string_eq(NULL, strlst_pop(strlst, -4));
+  mu_assert_int_eq(3, strlst_count(strlst));
+
+  mu_assert_int_eq(0, strlst_remove(strlst, -2));
+  mu_assert_int_eq(2, strlst_count(strlst));
+
+  mu_check(strlst_remove(strlst, 3));
+
+  mu_assert_string_eq("first",   strlst[0]);
+  mu_assert_string_eq("second",  strlst[1]);
+  mu_assert_string_eq(NULL,      strlst[2]);
+
+  strlst_free(strlst);
+}
 
 
 /***********************************************************************/
@@ -381,6 +432,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_strhex_decode);
   MU_RUN_TEST(test_strcategory);
   MU_RUN_TEST(test_strcatspn);
+  MU_RUN_TEST(test_strlst);
 }
 
 

--- a/storages/python/python-storage-plugins/yaml.py
+++ b/storages/python/python-storage-plugins/yaml.py
@@ -41,8 +41,8 @@ class yaml(dlite.DLiteStorageBase):
         self._data = {}  # data buffer
 
         if self.options.mode in ("r", "a", "append"):
-            with open(uri, "r") as handle:
-                data = pyyaml.safe_load(handle)
+            with open(uri, "r") as f:
+                data = pyyaml.safe_load(f)
             if data:
                 self._data = data
 
@@ -54,10 +54,10 @@ class yaml(dlite.DLiteStorageBase):
     def flush(self):
         """Flush cached data to storage."""
         if self.writable and not self.flushed:
-            with open(self.uri, "w") as handle:
-                self._pyyaml.dump(
+            with open(self.uri, "w") as f:
+                self._pyyaml.safe_dump(
                     self._data,
-                    handle,
+                    f,
                     default_flow_style=False,
                     sort_keys=False,
                 )
@@ -158,7 +158,7 @@ class yaml(dlite.DLiteStorageBase):
         Returns:
             The bytes (or bytearray) object that the instance is saved to.
         """
-        return pyyaml.dump(
+        return pyyaml.safe_dump(
             inst.asdict(soft7=soft7, uuid=with_uuid),
             default_flow_style=False,
             sort_keys=False,

--- a/storages/python/tests-c/CMakeLists.txt
+++ b/storages/python/tests-c/CMakeLists.txt
@@ -115,6 +115,9 @@ foreach(test ${tests})
   set_property(TEST ${test} APPEND PROPERTY
     ENVIRONMENT "DLITE_STORAGES=${CMAKE_CURRENT_SOURCE_DIR}/*.json|${dlite_SOURCE_DIR}/storages/python/python-storage-plugins/*.json")
 
+  # Skip tests that exit with return code 44
+  set_property(TEST ${test} PROPERTY SKIP_RETURN_CODE 44)
+
 endforeach()
 
 

--- a/storages/python/tests-c/test_bson_storage.c
+++ b/storages/python/tests-c/test_bson_storage.c
@@ -4,6 +4,15 @@
 #include "dlite-macros.h"
 #include "dlite-storage-plugins.h"
 
+
+// Not really a unit test, but check that the Python package "bson" is
+// available.  If not, exit with code 44, indicating that the test
+// should be skipped
+MU_TEST(test_for_bson)
+{
+  if (!dlite_pyembed_has_module("bson")) exit(44);
+}
+
 MU_TEST(test_save)
 {
   DLiteStorage* s = NULL;
@@ -124,6 +133,7 @@ MU_TEST(test_unload_plugins)
 
 MU_TEST_SUITE(test_suite)
 {
+  MU_RUN_TEST(test_for_bson);
   MU_RUN_TEST(test_save);
   MU_RUN_TEST(test_load);
   MU_RUN_TEST(test_unload_plugins);

--- a/storages/python/tests-c/test_bson_storage.c
+++ b/storages/python/tests-c/test_bson_storage.c
@@ -2,6 +2,7 @@
 
 #include "dlite.h"
 #include "dlite-macros.h"
+#include "pyembed/dlite-pyembed-utils.h"
 #include "dlite-storage-plugins.h"
 
 

--- a/storages/python/tests-c/test_postgresql_storage.c
+++ b/storages/python/tests-c/test_postgresql_storage.c
@@ -18,6 +18,16 @@ char *options = "database=" DATABASE ";user=" USER;
 #endif
 
 
+
+// Not really a unit test, but check that the Python package "psycopg"
+// is available.  If not, exit with code 44, indicating that the test
+// should be skipped
+MU_TEST(test_for_psycopg)
+{
+  if (!dlite_pyembed_has_module("psycopg")) exit(44);
+}
+
+
 MU_TEST(test_open_db)
 {
   mu_check((db = dlite_storage_open("postgresql", HOST, options)));
@@ -105,6 +115,7 @@ MU_TEST(test_unload_plugins)
 
 MU_TEST_SUITE(test_suite)
 {
+  MU_RUN_TEST(test_for_psycopg);
   MU_RUN_TEST(test_open_db);
   MU_RUN_TEST(test_save);
   MU_RUN_TEST(test_load);

--- a/storages/python/tests-c/test_postgresql_storage.c
+++ b/storages/python/tests-c/test_postgresql_storage.c
@@ -5,6 +5,7 @@
 
 #include "dlite.h"
 #include "dlite-macros.h"
+#include "pyembed/dlite-pyembed-utils.h"
 #include "dlite-storage-plugins.h"
 
 /* This header should define HOST, DATABASE, USER and PASSWORD */

--- a/storages/python/tests-c/test_postgresql_storage2.c
+++ b/storages/python/tests-c/test_postgresql_storage2.c
@@ -18,6 +18,14 @@ char *options = "database=" DATABASE ";user=" USER;
 #endif
 
 
+// Not really a unit test, but check that the Python package "psycopg"
+// is available.  If not, exit with code 44, indicating that the test
+// should be skipped
+MU_TEST(test_for_psycopg)
+{
+  if (!dlite_pyembed_has_module("psycopg")) exit(44);
+}
+
 
 MU_TEST(test_load_meta)
 {
@@ -52,6 +60,7 @@ MU_TEST(test_unload_plugins)
 
 MU_TEST_SUITE(test_suite)
 {
+  MU_RUN_TEST(test_for_psycopg);
   MU_RUN_TEST(test_load_inst);
   MU_RUN_TEST(test_load_meta);
   MU_RUN_TEST(test_unload_plugins);

--- a/storages/python/tests-c/test_postgresql_storage2.c
+++ b/storages/python/tests-c/test_postgresql_storage2.c
@@ -5,6 +5,7 @@
 
 #include "dlite.h"
 #include "dlite-macros.h"
+#include "pyembed/dlite-pyembed-utils.h"
 #include "dlite-storage-plugins.h"
 
 /* This header should define HOST, DATABASE, USER and PASSWORD */

--- a/storages/python/tests-c/test_yaml_storage.c
+++ b/storages/python/tests-c/test_yaml_storage.c
@@ -27,6 +27,9 @@ MU_TEST(test_load)
 {
   DLiteStorage *s;
   DLiteInstance *inst;
+
+  printf("\n***************************************************************\n");
+
   mu_check((s = dlite_storage_open("yaml", "test2.yaml", "mode=r")));
   mu_assert_int_eq(0, dlite_storage_is_writable(s));
 

--- a/storages/python/tests-c/test_yaml_storage.c
+++ b/storages/python/tests-c/test_yaml_storage.c
@@ -5,7 +5,17 @@
 
 #include "dlite.h"
 #include "dlite-macros.h"
+#include "pyembed/dlite-pyembed-utils.h"
 #include "dlite-storage-plugins.h"
+
+
+// Not really a unit test, but check that the Python package "yaml" is
+// available.  If not, exit with code 44, indicating that the test
+// should be skipped
+MU_TEST(test_for_yaml)
+{
+  if (!dlite_pyembed_has_module("yaml")) exit(44);
+}
 
 
 MU_TEST(test_save)
@@ -27,9 +37,6 @@ MU_TEST(test_load)
 {
   DLiteStorage *s;
   DLiteInstance *inst;
-
-  printf("\n***************************************************************\n");
-
   mu_check((s = dlite_storage_open("yaml", "test2.yaml", "mode=r")));
   mu_assert_int_eq(0, dlite_storage_is_writable(s));
 
@@ -55,6 +62,7 @@ MU_TEST(test_unload_plugins)
 
 MU_TEST_SUITE(test_suite)
 {
+  MU_RUN_TEST(test_for_yaml);
   MU_RUN_TEST(test_save);
   MU_RUN_TEST(test_load);
   MU_RUN_TEST(test_unload_plugins);

--- a/storages/python/tests-python/test_bson_storage_python.py
+++ b/storages/python/tests-python/test_bson_storage_python.py
@@ -7,6 +7,12 @@ from pathlib import Path
 sys.dont_write_bytecode = True
 from run_python_storage_tests import print_test_exception
 
+try:
+    import bson
+except ImportError:
+    print("bson not installed, skipping test")
+    sys.exit(44)  # skip test
+
 
 thisfile = Path(__file__)
 print(f'Running Python test <{thisfile.name}>...')

--- a/storages/python/tests-python/test_yaml_storage_python.py
+++ b/storages/python/tests-python/test_yaml_storage_python.py
@@ -4,7 +4,11 @@ import sys
 from importlib import util
 from pathlib import Path
 
-import yaml as pyyaml
+try:
+    import yaml as pyyaml
+except ImportError:
+    print("yaml not installed, skipping test")
+    sys.exit(44)  # skip test
 
 
 sys.dont_write_bytecode = True


### PR DESCRIPTION
 Description
 ===========
Avoid producing a huge number of irrelevant error messages from plugins depending on an unistalled Python package.
Create a simgle warning (that can be turned off) with information about plugins that does load.

Also make the code smarter such that it does not attempt to load a plugin again if it already has failed.

Little unrelated, this PR also skips tests that depend on Python packages not installed in the current environment.

Type of change
--------------
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

Checklist for the reviewer
--------------------------
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
