### PR TITLE
Avoid calling a plugin from a plugin

### DIFF
--- a/examples/storage_plugin/plugins/tempprofile.py
+++ b/examples/storage_plugin/plugins/tempprofile.py
@@ -8,10 +8,9 @@ class tempprofile(dlite.DLiteStorageBase):
 
     # At the time this plugin is importet, instantiate a TempProfile entity.
     # We keep a reference to this entity as a class attribute.
-    TempProfile = dlite.Instance.from_location(
-        "json", Path(__file__).resolve().parent.parent /
-        "entities" / "TempProfile.json",
-    )
+    with open(Path(__file__).resolve().parent.parent / "entities" /
+              "TempProfile.json", "r") as f:
+        TempProfile = dlite.Instance.from_json(f.read())
 
     def open(self, location, options=None):
         """Opens temperature profile.


### PR DESCRIPTION
 Description
 ===========
It is not intended to call a plugin from a plugin. Doing it seems to cause errors on some systems. 
The easy solution is simply avoiding it by replacing `dlite.Instance.from_location()` with `dlite.Instance.from_json()`.

Type of change
--------------
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

Checklist for the reviewer
--------------------------
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
