### PR TITLE
Fix segfault when calling Instance.to_bytes() for drivers not supporting memsave

### DIFF
--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -410,7 +410,11 @@ Call signatures:
   void to_bytes(const char *driver, unsigned char **ARGOUT_BYTES, size_t *LEN) {
     unsigned char *buf=NULL;
     int m, n = dlite_instance_memsave(driver, buf, 0, $self);
-    if (n < 0) return;
+    if (n < 0) {
+      *ARGOUT_BYTES = NULL;
+      *LEN = 0;
+      return;
+    }
     if (!(buf = malloc(n))) {
       dlite_err(dliteMemoryError, "allocation failure");
       return;

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -11,7 +11,7 @@ from dlite import Instance, Dimension, Property, Relation
 try:
     import pytest
     HAVE_PYTEST = True
-except ImportError:
+except ModuleNotFoundError:
     HAVE_PYTEST = False
 
 

--- a/bindings/python/tests/test_storage.py
+++ b/bindings/python/tests/test_storage.py
@@ -105,7 +105,7 @@ else:
 
 # Tests for issue #587
 bytearr = inst.to_bytes("yaml")
-print(bytes(bytearr).decode())
+#print(bytes(bytearr).decode())
 if HAVE_PYTEST:
     with pytest.raises(dlite.DLiteError):
         inst.to_bytes("json")

--- a/bindings/python/tests/test_storage.py
+++ b/bindings/python/tests/test_storage.py
@@ -4,6 +4,13 @@ import os
 
 import dlite
 
+try:
+    import pytest
+    HAVE_PYTEST = True
+except ModuleNotFoundError:
+    HAVE_PYTEST = False
+
+
 thisdir = os.path.abspath(os.path.dirname(__file__))
 
 url = 'json://' + thisdir + '/MyEntity.json'
@@ -35,7 +42,6 @@ myentity.save('json://myentity.json?mode=w')
 inst.save('json://inst.json?mode=w')
 del inst
 inst = dlite.Instance.from_url(f'json://{thisdir}/inst.json#my-data')
-
 
 
 # Test yaml
@@ -95,3 +101,11 @@ else:
     #del inst
     # FIXME: read from inst.ttl not db.xml
     inst3 = dlite.Instance.from_url('rdf://db.xml#my-data')
+
+
+# Tests for issue #587
+bytearr = inst.to_bytes("yaml")
+print(bytes(bytearr).decode())
+if HAVE_PYTEST:
+    with pytest.raises(dlite.DLiteError):
+        inst.to_bytes("json")


### PR DESCRIPTION
# Description
Closes #587 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
