### PR TITLE
Added support for Pydantic 2.x

### DIFF
--- a/bindings/python/tests/test_pydantic.py
+++ b/bindings/python/tests/test_pydantic.py
@@ -42,7 +42,7 @@ t = TransformationStatus(
     id="sim1",
     messages=["success", "timeout", "error"],
     created=now - 3600,
-    startTime=now - 3000,
+    startTime=int(now - 3000),
     finishTime=now - 600,
 )
 meta = pydantic_to_metadata(t)
@@ -65,8 +65,8 @@ class Foo(BaseModel):
 
 
 class Bar(BaseModel):
-    apple = 'x'
-    banana = 'y'
+    apple: str = 'x'
+    banana: str = 'y'
 
 
 class Spam(BaseModel):

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -220,7 +220,7 @@ def get_dataclass_entity_schema():
     @dataclass
     class Property:
         type: str
-        #ref: Optional[str]  # Hmm, how to create field name "@ref"?
+        #@ref: Optional[str]  # Should we rename this to "ref"? See issue #595
         shape: Optional[List[str]]
         unit: Optional[str]
         description: Optional[str]

--- a/examples/datamodel_as_rdf/README.md
+++ b/examples/datamodel_as_rdf/README.md
@@ -1,5 +1,12 @@
 Datamodels as RDF
 =================
-This example will show how DLite and Pydantic data models can be serialised to RDF.
+This example will show how DLite and Pydantic data models can be
+serialised to RDF.
 
-The example requires that you have Pydantic v1.x installed.
+Two examples are included:
+- **pydantic_nested**: Shows serialisation of nested pydantic models into RDF.
+  Works for both Pydantic v1 and v2.
+- **dataresource**: Shows serialisation of a Pydantic model of a OTEAPI
+  dataresource to RDF.  This example has two versions, one for Pydantic v1
+  ([dataresource.py](dataresource.py)) and one for Pydantic v2
+  ([dataresource_pydantic2.py](dataresource_pydantic2.py)).

--- a/examples/datamodel_as_rdf/dataresource.py
+++ b/examples/datamodel_as_rdf/dataresource.py
@@ -9,9 +9,9 @@ from dlite.rdf import from_rdf, to_rdf
 from dlite.utils import pydantic_to_instance, pydantic_to_metadata
 
 
-# Require Pydantic V1
+# Require Pydantic v1
 if int(pydantic_version.split(".")[0]) != 1:
-    print("This example requires pydantic V1")
+    print("This example requires pydantic v1")
     raise SystemExit(44)
 
 

--- a/examples/datamodel_as_rdf/dataresource.py
+++ b/examples/datamodel_as_rdf/dataresource.py
@@ -2,10 +2,17 @@
 from typing import Optional
 
 from pydantic import AnyUrl, BaseModel, Field, root_validator
+from pydantic import __version__ as pydantic_version
 
 import dlite
 from dlite.rdf import from_rdf, to_rdf
 from dlite.utils import pydantic_to_instance, pydantic_to_metadata
+
+
+# Require Pydantic V1
+if int(pydantic_version.split(".")[0]) != 1:
+    print("This example requires pydantic V1")
+    raise SystemExit(44)
 
 
 class HostlessAnyUrl(AnyUrl):
@@ -85,7 +92,7 @@ class ResourceConfig(BaseModel):
         ),
     )
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def ensure_unique_url_pairs(cls, values: "Dict[str, Any]") -> "Dict[str, Any]":
         """Ensure either downloadUrl/mediaType or accessUrl/accessService are
         defined.

--- a/examples/datamodel_as_rdf/dataresource_pydantic2.py
+++ b/examples/datamodel_as_rdf/dataresource_pydantic2.py
@@ -1,0 +1,186 @@
+"""RDF serialisation of a OTEAPI data resource."""
+from typing import Optional
+
+from typing_extensions import Annotated
+
+from pydantic import AnyUrl, BaseModel, Field, UrlConstraints, model_validator
+from pydantic import __version__ as pydantic_version
+
+import dlite
+from dlite.rdf import from_rdf, to_rdf
+from dlite.utils import pydantic_to_instance, pydantic_to_metadata
+
+
+# Require Pydantic v2
+if int(pydantic_version.split(".")[0]) != 2:
+    print("This example requires pydantic v2")
+    raise SystemExit(44)
+
+
+class ResourceConfig(BaseModel):
+    """Resource Strategy Data Configuration.
+
+    Important:
+        Either of the pairs of attributes `downloadUrl`/`mediaType` or
+        `accessUrl`/`accessService` MUST be specified.
+    """
+
+    downloadUrl: Annotated[
+        Optional[AnyUrl],
+        UrlConstraints(host_required=False),
+        Field(
+            None,
+            description=(
+                """Definition: The URL of the downloadable file in a given
+                format. E.g. CSV " "file or RDF file.
+
+                Usage: `downloadURL` *SHOULD* be used for the URL at which
+                this distribution is available directly, typically through a
+                HTTPS GET request or SFTP."""
+            ),
+        ),
+    ]
+    mediaType: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                """The media type of the distribution as defined by [IANA].
+
+                Usage: This property *SHOULD* be used when the media
+                type of the distribution is defined in [IANA].
+
+                [IANA]: https://www.w3.org/TR/vocab-dcat-2/#bib-iana-media-types
+                """
+            ),
+        ),
+    ]
+    accessUrl: Annotated[
+        Optional[AnyUrl],
+        UrlConstraints(host_required=False),
+        Field(
+            None,
+            description=(
+                """A URL of the resource that gives access to a distribution of
+                the dataset. E.g. landing page, feed, SPARQL endpoint.
+
+                Usage: `accessURL` *SHOULD* be used for the URL of a
+                service or location that can provide access to this
+                distribution, typically through a Web form, query or API
+                call.
+
+                `downloadURL` is preferred for direct links to downloadable
+                resources."""
+            ),
+        ),
+    ]
+    accessService: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                """A data service that gives access to the distribution of the
+                dataset."""
+            ),
+        ),
+    ]
+    license: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "A legal document under which the distribution is made "
+                "available."
+            ),
+        ),
+    ]
+    accessRights: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "A rights statement that concerns how the distribution is "
+                "accessed."
+            ),
+        ),
+    ]
+    publisher: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "The entity responsible for making the resource/item available."
+            ),
+        ),
+    ]
+
+    @model_validator(mode="after")
+    @classmethod
+    def ensure_unique_url_pairs(cls, data: "Any]") -> "Any":
+        """Ensure either downloadUrl/mediaType or accessUrl/accessService are
+        defined.
+
+        It's fine to define them all, but at least one complete pair
+        MUST be specified.
+        """
+        if not (data.downloadUrl and data.mediaType) or (
+            data.accessUrl and data.accessService
+        ):
+            raise ValueError(
+                "Either of the pairs of attributes downloadUrl/mediaType or "
+                "accessUrl/accessService MUST be specified."
+            )
+        return data
+
+
+config = {
+    "downloadUrl": "http://example.com/testdata.csv",
+    "mediaType": "text/csv",
+    "license": "CC-BY-4.0",
+}
+resource_config = ResourceConfig(**config)
+
+
+# Serialise to RDF
+DLiteResourceConfig = pydantic_to_metadata(ResourceConfig)
+dlite_config = pydantic_to_instance(DLiteResourceConfig, resource_config)
+
+
+rdf = to_rdf(dlite_config, format="turtle", include_meta=False, decode=True)
+print(rdf)
+
+
+# Try now to go from RDF to data model
+turtle = """
+@prefix dm: <http://emmo.info/datamodel/0.0.2#> .
+
+<6de3394f-615f-4b18-bae6-efcff13a2f0f> a dm:DataInstance ;
+    dm:hasProperty
+        <5ecf9c76-5997-4923-b085-566753cb59d7#downloadUrl>,
+        <5ecf9c76-5997-4923-b085-566753cb59d7#license>,
+        <5ecf9c76-5997-4923-b085-566753cb59d7#mediaType> ;
+    dm:hasUUID "6de3394f-615f-4b18-bae6-efcff13a2f0f" ;
+    dm:instanceOf <http://onto-ns.com/meta/0.1/ResourceConfig> .
+
+<5ecf9c76-5997-4923-b085-566753cb59d7#downloadUrl> dm:hasLabel "downloadUrl" ;
+    dm:hasValue "http://example.com/testdata.csv" ;
+    dm:instanceOf <http://onto-ns.com/meta/0.1/ResourceConfig#downloadUrl> .
+
+<5ecf9c76-5997-4923-b085-566753cb59d7#license> dm:hasLabel "license" ;
+    dm:hasValue "CC-BY-4.0" ;
+    dm:instanceOf <http://onto-ns.com/meta/0.1/ResourceConfig#license> .
+
+<5ecf9c76-5997-4923-b085-566753cb59d7#mediaType> dm:hasLabel "mediaType" ;
+    dm:hasValue "text/csv" ;
+    dm:instanceOf <http://onto-ns.com/meta/0.1/ResourceConfig#mediaType> .
+"""
+
+inst = from_rdf(data=turtle, format="turtle")
+new_resource_config = ResourceConfig(**inst.properties)
+
+
+# If we create our pydantic model from the rdf representation - check
+# that we get back the original model
+inst2 = from_rdf(data=rdf, format="turtle")
+new_resource_config2 = ResourceConfig(**inst.properties)
+assert new_resource_config2.model_dump() == resource_config.model_dump()

--- a/examples/datamodel_as_rdf/main.py
+++ b/examples/datamodel_as_rdf/main.py
@@ -1,3 +1,15 @@
 """Main script running all tests in this repo."""
-import pydantic_nested
-import dataresource
+import pydantic
+
+
+pydantic_major = int(pydantic.__version__.split(".")[0])
+
+# Run examples
+import pydantic_nested  # works for both Pydantic v1 and v2
+
+if pydantic_major == 1:
+    # Only Pydantic v1
+    import dataresource
+elif pydantic_major == 2:
+    # Only Pydantic v2
+    import dataresource_pydantic2

--- a/examples/mappings/mappingfunc.py
+++ b/examples/mappings/mappingfunc.py
@@ -90,7 +90,7 @@ def norm(array, axis=-1):
 
 def max(vector):
     """Returns the largest element."""
-    return np.max(vector)
+    return vector.max()
 
 
 # Add mappings for conversion functions -- ontologist

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pint>=0.15,<0.23
 openpyxl>=3.0.9,<3.2
 pymongo>=4.4.0,<5
 tripper>=0.2.5,<0.3
-pydantic>=1.10.0,<2
-#typing_extensions>=4.6,5
+pydantic>=1.10.0,<3
+typing_extensions>=4.1,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pint>=0.15,<0.23
 openpyxl>=3.0.9,<3.2
 pymongo>=4.4.0,<5
 tripper>=0.2.5,<0.3
-pydantic>=1.10.0,<3
+pydantic>=1.10.0,<2
 typing_extensions>=4.1,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ openpyxl>=3.0.9,<3.2
 pymongo>=4.4.0,<5
 tripper>=0.2.5,<0.3
 pydantic>=1.10.0,<2
-
+#typing_extensions>=4.6,5


### PR DESCRIPTION
# Description
Closes #574 

Added support for Pydantic 2.x. Support for Pydantic 1.x is retained.

Also ensure that the mapping example runs with the very old version of Pint (v0.16) required by AiiDA.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
