### PR TITLE
Added --package option to patch-activate.sh script

### DIFF
--- a/cmake/patch-activate.sh
+++ b/cmake/patch-activate.sh
@@ -1,12 +1,60 @@
-#!/bin/sh
-#
-# Patch virtualenv activate script to support LD_LIBRARY_PATH
-#
+#!/bin/bash
+
+help() {
+cat <<EOF
+Usage: patch-activate.sh [--package PACKAGE]
+
+Patch virtualenv activate script to support LD_LIBRARY_PATH
+
+Options:
+  -h, --help   Show this help and exit.
+  -p PACKAGE, --package PACKAGE
+               Insert root directory of this Python package to
+               LD_LIBRARY_PATH.
+
+How to use this script:
+  1. Make sure that environment variable VIRTUAL_ENV is set to the
+     root directory of your virtual environments.
+  2. Activate your virtual environment.
+  3. Run `patch-activate.sh`
+  4. Deactivate and reactivate your virtual environment to ensure that
+     LD_LIBRARY_PATH is properly set.
+EOF
+}
+
+# Usage: app_package PACKAGE
+# Append path to root of Python package to `libdirs`
+add_package() {
+    pkgdir=$(dirname $(python -c "import $1; print($1.__file__)"))
+    relpath=$(realpath --relative-to="$VIRTUAL_ENV" "$pkgdir")
+    if [ "${relpath#..}" = "$relpath" ]; then
+        libdirs="$libdirs:\$VIRTUAL_ENV/$relpath"
+    else
+        echo ""; exit 1
+    fi
+}
+
+
+set -e
 
 if [ -z "$VIRTUAL_ENV" ]; then
    echo "Not in a virtual environment" >&2
    exit 1
 fi
+
+libdirs="\$VIRTUAL_ENV/lib"
+
+# Parse options
+while true; do
+    case "$1" in
+        '')            break;;
+        -h|--help)     help; exit 0;;
+        -p|--package)  add_package $2; shift;;
+        *)             echo "Invalid argument: '$1'"; exit 1;;
+    esac
+    shift
+done
+
 
 cd $VIRTUAL_ENV/bin
 
@@ -30,7 +78,7 @@ patch -u -f -F 1 <<EOF
  export PATH
 
 +_OLD_VIRTUAL_LD_LIBRARY_PATH="\$LD_LIBRARY_PATH"
-+LD_LIBRARY_PATH="\$VIRTUAL_ENV/lib:\$LD_LIBRARY_PATH"
++LD_LIBRARY_PATH="$libdirs:\$LD_LIBRARY_PATH"
 +export LD_LIBRARY_PATH
 +
  # unset PYTHONHOME if set


### PR DESCRIPTION
# Description
Added --package option to patch-activate.sh script. This option is needed by the tools like dlite-getuuid when dlite is installed with pip. The reason for this is that the pip package places libdlite.so in the root of the python package instead of in `$VIRTUAL_ENV/lib/`.

The order of the paths in LD_LIBRARY_PATH ensures that shared libraries installed from source get precedence over shared libraries installed with pip.

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
