### PR TITLE
Make figures show up correctly in README on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ been supported by several projects, including:
   - [OpenModel](https://www.open-model.eu/) (2021-2025) that receives funding from the European Union’s Horizon 2020 Research and Innovation Programme, under Grant Agreement n. 953167.
   - [DOME 4.0](https://dome40.eu/) (2021-2025) that receives funding from the European Union’s Horizon 2020 Research and Innovation Programme, under Grant Agreement n. 953163.
   - [VIPCOAT](https://www.vipcoat.eu/) (2021-2025) that receives funding from the European Union’s Horizon 2020 Research and Innovation Programme, under Grant Agreement n. 952903.
-
+  - MEDIATE (2022-2025) that receives funding from the RCN, Norway; FNR, Luxenburg; SMWK Germany via the M-era.net programme, project9557,
+  - [MatCHMaker](https://he-matchmaker.eu/) (2022-2026) that receives funding from the European Union’s Horizon 2020 Research and Innovation Programme, under Grant Agreement n. 101091687.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="doc/_static/logo.svg" align="right" />
+<img src="https://raw.githubusercontent.com/SINTEF/dlite/master/doc/_static/logo.svg" align="right" />
 
 
 DLite
@@ -17,7 +17,7 @@ DLite is a C implementation of the [SINTEF Open Framework and Tools
 models (aka Metadata) to efficiently describe and work with scientific
 data.
 
-![DLite overview](doc/_static/overview.svg)
+![DLite overview](https://raw.githubusercontent.com/SINTEF/dlite/master/doc/_static/overview.svg)
 
 The core of DLite is a framework for formalised representation of data
 described by data models (called Metadata or Entity in DLite).


### PR DESCRIPTION
# Description
Added absolute link to figures in README file such that they show up correctly on PyPI: https://pypi.org/project/DLite-Python/. 

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
