### PR TITLE
Support quoted relations in collection

### DIFF
--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -161,8 +161,22 @@ int _dlite_json_sprint(char *dest, size_t size, const DLiteInstance *inst,
     if (dlite_instance_get_property((DLiteInstance *)inst->meta, "relations")) {
       PRINT1("%s  \"relations\": [\n", in);
       for (i=0; i < met->_nrelations; i++) {
+        int m;
         DLiteRelation *r = met->_relations + i;
-        PRINT4("%s    [\"%s\", \"%s\", \"%s\"]\n", in, r->s, r->p, r->o);
+        PRINT1("%s    [", in);
+        m = strquote(dest+n, PDIFF(size, n), r->s);
+        if (m < 0) goto fail;
+        n += m;
+        PRINT(", ");
+        m = strquote(dest+n, PDIFF(size, n), r->p);
+        if (m < 0) goto fail;
+        n += m;
+        PRINT(", ");
+        m = strquote(dest+n, PDIFF(size, n), r->o);
+        if (m < 0) goto fail;
+        n += m;
+        PRINT("]\n");
+
       }
       PRINT2("%s  ]%s\n", in, prop_comma);
     }
@@ -212,8 +226,21 @@ int _dlite_json_sprint(char *dest, size_t size, const DLiteInstance *inst,
     if (dlite_instance_get_property((DLiteInstance *)inst->meta, "relations")) {
       PRINT1("%s  \"relations\": [\n", in);
       for (i=0; i < met->_nrelations; i++) {
+        int m;
         DLiteRelation *r = met->_relations + i;
-        PRINT4("%s    [\"%s\", \"%s\", \"%s\"]\n", in, r->s, r->p, r->o);
+        PRINT1("%s    [", in);
+        m = strquote(dest+n, PDIFF(size, n), r->s);
+        if (m < 0) goto fail;
+        n += m;
+        PRINT(", ");
+        m = strquote(dest+n, PDIFF(size, n), r->p);
+        if (m < 0) goto fail;
+        n += m;
+        PRINT(", ");
+        m = strquote(dest+n, PDIFF(size, n), r->o);
+        if (m < 0) goto fail;
+        n += m;
+        PRINT("]\n");
       }
       PRINT2("%s  ]%s\n", in, prop_comma);
     }

--- a/src/dlite-type.c
+++ b/src/dlite-type.c
@@ -923,6 +923,15 @@ int dlite_type_aprint(char **dest, size_t *n, size_t pos, const void *p,
 #define MAX_PROPERTY_TOKENS  64  // this supports at least 50 dimensions...
 #define MAX_RELATION_TOKENS   9
 
+/* Macro used by dlite_type_scan() to asign `target` when scanning a
+   relation. */
+#define SET_RELATION(target, buf, bufsize, t, src)                      \
+  if (strnput_unquote(&buf, &bufsize, 0, src + t->start,                \
+                      t->end - t->start, NULL, strquoteNoQuote) < 0)    \
+    return -1;                                                          \
+  target = strndup(buf, t->end - t->start);
+
+
 /*
   Scans a value from `src` and write it to memory pointed to by `p`.
 
@@ -1207,23 +1216,11 @@ int dlite_type_scan(const char *src, int len, void *p, DLiteType dtype,
         size_t bufsize=0;
         char *buf=NULL;
         if (!(t = jsmn_element(src, tokens, 0))) return -1;
-        if (strnput_unquote(&buf, &bufsize, 0, src + t->start,
-                            t->end - t->start, NULL, strquoteNoQuote) < 0)
-          return -1;
-        rel->s = strndup(buf, t->end - t->start);
-
+        SET_RELATION(rel->s, buf, bufsize, t, src);
         if (!(t = jsmn_element(src, tokens, 1))) return -1;
-        if (strnput_unquote(&buf, &bufsize, 0, src + t->start,
-                            t->end - t->start, NULL, strquoteNoQuote) < 0)
-          return -1;
-        rel->p = strndup(buf, t->end - t->start);
-
+        SET_RELATION(rel->p, buf, bufsize, t, src);
         if (!(t = jsmn_element(src, tokens, 2))) return -1;
-        if (strnput_unquote(&buf, &bufsize, 0, src + t->start,
-                            t->end - t->start, NULL, strquoteNoQuote) < 0)
-          return -1;
-        rel->o = strndup(buf, t->end - t->start);
-
+        SET_RELATION(rel->o, buf, bufsize, t, src);
         if (tokens->size > 3 && (t = jsmn_element(src, tokens, 3)))
           rel->id = strndup(src + t->start, t->end - t->start);
         free(buf);
@@ -1231,20 +1228,11 @@ int dlite_type_scan(const char *src, int len, void *p, DLiteType dtype,
         size_t bufsize=0;
         char *buf=NULL;
         if (!(t = jsmn_item(src, tokens, "s"))) return -1;
-        if (strnput_unquote(&buf, &bufsize, 0, src + t->start,
-                            t->end - t->start, NULL, strquoteNoQuote) < 0)
-          return -1;
-        rel->s = strndup(buf, t->end - t->start);
+        SET_RELATION(rel->s, buf, bufsize, t, src);
         if (!(t = jsmn_item(src, tokens, "p"))) return -1;
-        if (strnput_unquote(&buf, &bufsize, 0, src + t->start,
-                            t->end - t->start, NULL, strquoteNoQuote) < 0)
-          return -1;
-        rel->p = strndup(buf, t->end - t->start);
+        SET_RELATION(rel->p, buf, bufsize, t, src);
         if (!(t = jsmn_item(src, tokens, "o"))) return -1;
-        if (strnput_unquote(&buf, &bufsize, 0, src + t->start,
-                            t->end - t->start, NULL, strquoteNoQuote) < 0)
-          return -1;
-        rel->o = strndup(buf, t->end - t->start);
+        SET_RELATION(rel->o, buf, bufsize, t, src);
         if ((t = jsmn_item(src, tokens, "id")))
           rel->id = strndup(src + t->start, t->end - t->start);
         free(buf);

--- a/src/tests/test_json.c
+++ b/src/tests/test_json.c
@@ -77,7 +77,6 @@ MU_TEST(test_sprint)
   //printf("%s\n", buf);
   mu_assert_int_eq(1165, m);
 
-  //printf("\n========================================================\n");
 
 
   /* Tests for PR #541 */
@@ -87,6 +86,16 @@ MU_TEST(test_sprint)
   m = dlite_json_sprint(NULL, 0, inst, 4, dliteJsonSingle);
   mu_assert_int_eq(404, m);
 
+
+  /* Tests for proper quoting */
+  DLiteCollection *coll = dlite_collection_create(NULL);
+  dlite_collection_add_relation(coll, "s", "p", "\"o\"");
+  m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)coll, 2, 0);
+  printf("\n--------------------------------------------------------\n");
+  printf("%s\n", buf);
+  printf("\n--------------------------------------------------------\n");
+
+  //printf("\n========================================================\n");
 }
 
 

--- a/src/tests/test_json.c
+++ b/src/tests/test_json.c
@@ -91,9 +91,12 @@ MU_TEST(test_sprint)
   DLiteCollection *coll = dlite_collection_create(NULL);
   dlite_collection_add_relation(coll, "s", "p", "\"o\"");
   m = dlite_json_sprint(buf, sizeof(buf), (DLiteInstance *)coll, 2, 0);
-  printf("\n--------------------------------------------------------\n");
-  printf("%s\n", buf);
-  printf("\n--------------------------------------------------------\n");
+  const DLiteRelation *rel = dlite_collection_find_first(coll, "s", "p", NULL);
+  mu_assert_string_eq("\"o\"", rel->o);
+  dlite_instance_decref((DLiteInstance *)coll);
+  //printf("\n--------------------------------------------------------\n");
+  //printf("%s\n", buf);
+
 
   //printf("\n========================================================\n");
 }

--- a/src/utils/strutils.h
+++ b/src/utils/strutils.h
@@ -189,6 +189,15 @@ int strunquote(char *dest, size_t size, const char *s,
 int strnunquote(char *dest, size_t size, const char *s, int n,
                int *consumed, StrquoteFlags flags);
 
+/**
+  Like strnunquote(), but reallocates the destination and writes to
+  position `pos`.
+
+  On allocation error, -3 is returned.
+ */
+int strnput_unquote(char **destp, size_t *sizep, size_t pos, const char *s,
+                    int n, int *consumed, StrquoteFlags flags);
+
 
 /** @} */
 /**

--- a/src/utils/tests/test_strutils.c
+++ b/src/utils/tests/test_strutils.c
@@ -219,6 +219,34 @@ MU_TEST(test_strunquote)
 }
 
 
+MU_TEST(test_strput_unquote)
+{
+  char *buf=NULL;
+  size_t size=0;
+  int n, consumed;
+
+  n = strnput_unquote(&buf, &size, 0, "\"123\"", 4, &consumed, 0);
+  mu_assert_int_eq(3, n);
+  mu_assert_int_eq(4, consumed);
+  mu_assert_int_eq(4, size);
+  mu_assert_string_eq("123", buf);
+
+  n = strnput_unquote(&buf, &size, 2, "\"abc\"", 4, &consumed, 0);
+  mu_assert_int_eq(3, n);
+  mu_assert_int_eq(4, consumed);
+  mu_assert_int_eq(6, size);
+  mu_assert_string_eq("12abc", buf);
+
+  n = strnput_unquote(&buf, &size, 0, "  \"123\" + 4 ", -1, &consumed, 0);
+  mu_assert_int_eq(3, n);
+  mu_assert_int_eq(7, consumed);
+  mu_assert_int_eq(6, size);
+  mu_assert_string_eq("123", buf);
+
+  free(buf);
+}
+
+
 MU_TEST(test_strhex_encode)
 {
   unsigned char data[4] = {0x61, 0x62, 0x63, 0x64};
@@ -428,6 +456,7 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_strquote);
   MU_RUN_TEST(test_strnquote);
   MU_RUN_TEST(test_strunquote);
+  MU_RUN_TEST(test_strput_unquote);
   MU_RUN_TEST(test_strhex_encode);
   MU_RUN_TEST(test_strhex_decode);
   MU_RUN_TEST(test_strcategory);


### PR DESCRIPTION
# Description
We use the collection as a local knowledge base. Since n3-represented literals contains embedded double-quotes it is essential that serialisation and de-serialisation of collections retain embedded double-quotes.

This PR ensures that embedded double-quotes are escaped in the internal representation of relations, which is used by the built-in json encoder/decoder.

## Type of change
- [x] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [x] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
