### PR TITLE
Fixed issue with creating metadata

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -39,6 +39,9 @@ class Metadata(Instance):
         return Instance.create_metadata(
             uri, dimensions, properties, description)
 
+    def __init__(self, *args, **kwargs):
+        pass  # do nothing, just avoid calling Instance.__init__()
+
     def __repr__(self):
         return f"<Metadata: uri='{self.uri}'>"
 

--- a/bindings/python/tests/test_ref_create.py
+++ b/bindings/python/tests/test_ref_create.py
@@ -1,0 +1,24 @@
+import dlite
+
+
+# Create two entities with ref properties that cyclic refer to each other...
+prop_a = dlite.Property("a", "ref", "http://onto-ns.com/meta/0.1/A")
+B = dlite.Metadata(
+    "http://onto-ns.com/meta/0.1/B", dimensions=[], properties=[prop_a],
+)
+
+prop_v = dlite.Property("v", "int")
+prop_b = dlite.Property("b", "ref", "http://onto-ns.com/meta/0.1/B")
+A = dlite.Metadata(
+    "http://onto-ns.com/meta/0.1/A", dimensions=[], properties=[prop_v, prop_b],
+)
+
+# Create instances
+b = B()
+a = A(properties={"v": 3, "b": b})
+b.a = a
+
+
+assert a.v == 3
+assert a.b == b
+assert b.a == a


### PR DESCRIPTION
# Description
Avoid calling `dlite.Instance.__init__()` when creating new metadata using the dlite.Metadata constructor, since there is no need for it (and avoids DLite calling abort() because it ends up in an unexpected case...).

Added test that both tests creation of metadata and that it is possible to create two metadata with ref-properties that cyclic refer to each other.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [x] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
