### PR TITLE
Made it easy to silence specific DLite error messages both in C and Python

### DIFF
--- a/bindings/python/dlite-misc-python.i
+++ b/bindings/python/dlite-misc-python.i
@@ -4,29 +4,57 @@
 
 %pythoncode %{
 
-class err():
-    """Context manager for temporary turning off or redirecting errors.
+class errctl():
+    """Context manager for temporary disabling specific DLite error
+    messages or redirecting them.
 
-    By default errors are skipped within the err context. But if
-    `filename` is provided, the error messages are written to that file.
-    Special file names includes:
-
-    - "None" or empty: No output is written.
-    - "<stderr>": Write errors to stderr (default).
-    - "<stdout>": Write errors to stdout.
+    Arguments:
+        hide: Sequence of DLiteException subclasses or exception names
+            corresponding to error messages to hide.  A single class or
+            name is also allowed.
+        show: Sequence of DLiteException subclasses or exception names
+            corresponding to error messages to show.  A single class or
+            name is also allowed.
+        filename: Filename to redirect errors to.  The following values
+            are handled specially:
+              - "None" or empty: No output is written.
+              - "<stderr>": Write errors to stderr (default).
+              - "<stdout>": Write errors to stdout.
 
     """
-    def __init__(self, filename=None):
+    def __init__(self, hide=(), show=(), filename="<stderr>"):
+        self.hide = self._as_codes(hide)
+        self.show = self._as_codes(show)
         self.filename = filename
 
     def __enter__(self):
+        self.mask = _dlite._err_mask_get()
+        for code in self.hide:
+            _dlite._err_ignore_set(code, 1)
+        for code in self.show:
+            _dlite._err_ignore_set(code, 0)
         self.f = _dlite.err_get_stream()
         _dlite.err_set_file(self.filename)
-        return self.f
 
     def __exit__(self, *exc):
-        _dlite.errclr()
+        ignored = _dlite._err_ignore_get(_dlite.errval())
+        _dlite._err_mask_set(self.mask)
         _dlite.err_set_stream(self.f)
+        if ignored or self.filename is None:
+            _dlite.errclr()
 
-silent = err()
+    @staticmethod
+    def _as_codes(seq):
+        """Return sequence of exceptions/exception names as a sequence of
+        DLite error coces.  `seq` may also be a single exception or name."""
+        sequence = [seq] if isinstance(seq, (str, type)) else seq
+        return [
+            _dlite._err_getcode(
+                exc.__name__ if isinstance(exc, type) else str(exc)
+            )
+            for exc in sequence
+        ]
+
+
+silent = errctl(filename="None")
 %}

--- a/bindings/python/dlite-misc.i
+++ b/bindings/python/dlite-misc.i
@@ -27,7 +27,13 @@
     return atob(str);
   }
 
+  int64_t _err_mask_get(void) {
+    return *_dlite_err_mask_get();
+  }
+
 %}
+
+%include <stdint.i>
 
 %feature("docstring", "\
 Returns the current version of DLite.
@@ -158,6 +164,29 @@ All other values are treated as a filename that will be opened in append mode.
 ") dlite_err_set_file;
 void dlite_err_set_file(const char *filename);
 
+%feature("docstring", "\
+Return DLite error code corresponding to `name`.  Unknown names will return
+`dliteUnknownError`.
+") dlite_errcode;
+%rename(_err_getcode) dlite_errcode;
+int dlite_errcode(const char *name);
+
+/* Private help functions */
+%feature("docstring", "\
+Set whether to ignore printing given error code.
+") dlite_err_ignored_set;
+%rename(_err_ignore_set) dlite_err_ignored_set;
+void dlite_err_ignored_set(int code, int value);
+
+%feature("docstring", "\
+Return whether printing is ignored for given error code.
+") dlite_err_ignored_get;
+%rename(_err_ignore_get) dlite_err_ignored_get;
+int dlite_err_ignored_get(int code);
+
+int64_t _err_mask_get(void);
+%rename(_err_mask_set) _dlite_err_mask_set;
+void _dlite_err_mask_set(int64_t mask);
 
 
 /* ------------------------------

--- a/bindings/python/tests/test_misc.py
+++ b/bindings/python/tests/test_misc.py
@@ -40,3 +40,26 @@ assert dlite.split_url("driver://loc#fragment") == [
     "fragment",
 ]
 assert dlite.split_url("loc#fragment") == ["", "loc", "", "fragment"]
+
+
+# Test errctl context manager
+print("No DLite error message is printed to screen:")
+try:
+    with dlite.errctl(hide=(dlite.DLiteStorageOpenError, dlite.DLiteError)):
+        dlite.Instance.from_location("-", "__non-existing__")
+except dlite.DLiteStorageOpenError:
+    pass
+
+print("No DLite error message is printed to screen:")
+try:
+    with dlite.errctl(hide="DLiteError"):
+        dlite.Instance.from_location("-", "__non-existing__")
+except dlite.DLiteStorageOpenError:
+    pass
+
+print("DLite error message is printed to screen:")
+try:
+    with dlite.errctl(hide=dlite.DLiteTypeError):
+        dlite.Instance.from_location("-", "__non-existing__")
+except dlite.DLiteStorageOpenError:
+    pass

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -142,9 +142,7 @@ def instance_from_dict(d, id=None, single=None, check_storages=True):
         if check_storages:
             try:
                 with dlite.silent:
-                    inst = dlite.get_instance(uri)
-                    if inst:
-                        return inst
+                    return dlite.get_instance(uri)
             except dlite.DLiteError:
                 pass
 

--- a/src/dlite-bson.c
+++ b/src/dlite-bson.c
@@ -10,7 +10,6 @@
 
 #include "dlite-entity.h"
 #include "dlite-macros.h"
-#include "dlite-errors.h"
 #include "dlite-type.h"
 #include "dlite-bson.h"
 
@@ -518,6 +517,8 @@ static int set_meta_dimensions(DLiteMeta *meta, unsigned char *subdoc)
     }
     p++;
   }
+  dlite_meta_init(meta);
+
   if (nprops != meta->_nproperties)
     return err(dliteIndexError, "too few properties in bson, got  %d, "
                "expected %d", (int)nprops, (int)meta->_nproperties);

--- a/src/dlite-errors.c
+++ b/src/dlite-errors.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 
 #include "dlite-errors.h"
 
@@ -7,10 +8,10 @@
   Returns the name corresponding to error code (with the final "Error" stripped
   off).
  */
-const char *dlite_errname(DLiteErrors code)
+const char *dlite_errname(DLiteErrCode code)
 {
   switch (code) {
-  case dliteSuccess:                return "DLiteSussess";
+  case dliteSuccess:                return "DLiteSuccess";
   case dliteUnknownError:           return "DLiteUnknown";
   case dliteIOError:                return "DLiteIO";
   case dliteRuntimeError:           return "DLiteRuntime";
@@ -40,7 +41,7 @@ const char *dlite_errname(DLiteErrors code)
   case dliteMetadataExistError:     return "DLiteMetadataExist";
   case dlitePythonError:            return "DLitePython";
 
-  case dliteLastError:              return "DLiteLast";
+  case dliteLastError:              return "DLiteUndefined";
   }
   if (code < 0) return "DLiteUndefined";
   return "DLiteOther";
@@ -50,10 +51,10 @@ const char *dlite_errname(DLiteErrors code)
 /*
   Returns a description of the corresponding to error code
  */
-const char *dlite_errdescr(DLiteErrors code)
+const char *dlite_errdescr(DLiteErrCode code)
 {
   switch (code) {
-  case dliteSuccess:                return "Sussess";
+  case dliteSuccess:                return "Success";
   case dliteUnknownError:           return "Generic unknown error";
   case dliteIOError:                return "I/O related error";
   case dliteRuntimeError:           return "Unspecified run-time error";
@@ -85,4 +86,24 @@ const char *dlite_errdescr(DLiteErrors code)
   case dliteLastError:              return NULL;
   }
   return NULL;
+}
+
+
+/*
+  Return DLite error code corresponding to `name`.
+
+  Special cases:
+    - Unknown names will return `dliteUnknownError`.
+    - "DLiteError" will return zero.
+ */
+DLiteErrCode dlite_errcode(const char *name)
+{
+  DLiteErrCode code;
+  if (strncmp("DLiteError", name, 10) == 0) return 0;
+  for (code=0; code>dliteLastError; code--) {
+    const char *errname = dlite_errname(code);
+    if (strncmp(errname, name, strlen(errname)) == 0)
+      return code;
+  }
+  return dliteUnknownError;
 }

--- a/src/dlite-errors.h
+++ b/src/dlite-errors.h
@@ -38,19 +38,26 @@ typedef enum {
 
   /* Should always be the last error */
   dliteLastError=-28
-} DLiteErrors;
+} DLiteErrCode;
 
 
 /**
   Returns the name corresponding to error code
  */
-const char *dlite_errname(DLiteErrors code);
+const char *dlite_errname(DLiteErrCode code);
 
 
 /**
   Returns a description of the corresponding to error code
  */
-const char *dlite_errdescr(DLiteErrors code);
+const char *dlite_errdescr(DLiteErrCode code);
+
+
+/**
+  Return DLite error code corresponding to `name`.  Unknown names will
+  return `dliteUnknownError`.
+ */
+DLiteErrCode dlite_errcode(const char *name);
 
 
 #endif  /* _DLITE_ERRORS_H */

--- a/src/dlite-mapping-plugins.c
+++ b/src/dlite-mapping-plugins.c
@@ -16,7 +16,6 @@
 #include "dlite-datamodel.h"
 #include "dlite-mapping-plugins.h"
 #include "dlite-macros.h"
-#include "dlite-errors.h"
 #ifdef WITH_PYTHON
 #include "pyembed/dlite-python-mapping.h"
 #endif

--- a/src/dlite-mapping.c
+++ b/src/dlite-mapping.c
@@ -13,7 +13,6 @@
 #include "dlite-entity.h"
 #include "dlite-mapping-plugins.h"
 #include "dlite-mapping.h"
-#include "dlite-errors.h"
 
 
 /*

--- a/src/dlite-misc.c
+++ b/src/dlite-misc.c
@@ -16,6 +16,7 @@
 #include "getuuid.h"
 #include "dlite.h"
 #include "dlite-macros.h"
+#include "dlite-errors.h"
 
 /* Global variables */
 static int use_build_root = -1;   /* whether to use build root */
@@ -461,6 +462,7 @@ int dlite_add_dll_path(void)
 #define ATEXIT_MARKER_ID "dlite-atexit-marker-id"
 
 #define ERR_STATE_ID "err-globals-id"
+#define ERR_MASK_ID "err-ignored-id"
 
 
 /* A cache pointing to the current session handler */
@@ -523,8 +525,10 @@ void dlite_globals_set(DLiteGlobals *globals_handler)
 /* Error handler for DLite. */
 static void dlite_err_handler(const ErrRecord *record)
 {
-  FILE *stream = err_get_stream();
-  if (stream) fprintf(stream, "** %s\n", record->msg);
+  if (!dlite_err_ignored_get(record->eval)) {
+    FILE *stream = err_get_stream();
+    if (stream) fprintf(stream, "** %s\n", record->msg);
+  }
 }
 
 
@@ -595,6 +599,53 @@ int dlite_globals_in_atexit(void)
 /********************************************************************
  * Wrappers around error functions
  ********************************************************************/
+
+
+/* Returns pointer to bit flags for error codes to not print or NULL
+   on error. */
+DLiteErrMask *_dlite_err_mask_get(void)
+{
+  DLiteErrMask *mask = dlite_globals_get_state(ERR_MASK_ID);
+  if (!mask) {
+    // Check that if we have fewer error codes than bits in DLiteErrMask
+    assert(8*sizeof(DLiteErrMask) > -dliteLastError);
+
+    if (!(mask = calloc(1, sizeof(DLiteErrMask))))
+      return fprintf(stderr, "** allocation failure"), NULL;
+    dlite_globals_add_state(ERR_MASK_ID, mask, free);
+  }
+  return mask;
+}
+
+/* Set mask for error to not print. */
+void _dlite_err_mask_set(DLiteErrMask mask)
+{
+  DLiteErrMask *errmask = _dlite_err_mask_get();
+  if (errmask) *errmask = mask;
+}
+
+
+/* Set whether to ignore printing given error code. */
+void dlite_err_ignored_set(DLiteErrCode code, int value)
+{
+  DLiteErrMask *mask = _dlite_err_mask_get();
+  int bit = DLITE_ERRBIT(code);
+  if (mask) {
+    if (value)
+      *mask |= bit;
+    else
+      *mask &= ~bit;
+  }
+}
+
+/* Return whether printing is ignored for given error code. */
+int dlite_err_ignored_get(DLiteErrCode code)
+{
+  DLiteErrMask *mask = _dlite_err_mask_get();
+  if (!mask) return 0;
+  return *mask & DLITE_ERRBIT(code);
+}
+
 
 /* ----------------------------------------------------------- */
 /* TODO:

--- a/src/dlite-misc.h
+++ b/src/dlite-misc.h
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 #include "utils/fileutils.h"
+#include "dlite-errors.h"
 #include "dlite-type.h"
 
 #define DLITE_UUID_LENGTH 36  /*!< length of an uuid (excl. NUL-termination) */
@@ -288,8 +289,47 @@ int dlite_globals_in_atexit(void);
 
 /**
   @name Wrappers around error functions
+  The `DLITE_NOERR()` and `DLITE_NOERR_END` macros are intended to
+  mark a code block in which the specified errors will not be printed.
+  Use them as follows:
+
+  ```c
+  DLITE_NOERR(DLITE_ERRBIT(DLiteIOError) | DLITE_ERRBIT(DLiteRuntimeError));
+    // code block where IO and runtime errors are ignored
+    ...
+  DLITE_NOERR_END;
+  ```
   @{
 */
+
+/* Bit mask of error codes to not print*/
+typedef int64_t DLiteErrMask;
+
+/* Get ans set global mask for error codes to not print. */
+DLiteErrMask *_dlite_err_mask_get(void);
+void _dlite_err_mask_set(DLiteErrMask mask);
+
+#define DLITE_ERRBIT(code)                                              \
+  (1<<((code >= 0) ? 0 : (code <= dliteLastError) ? -dliteLastError : -code))
+
+#define DLITE_NOERR(mask)                                       \
+  do {                                                          \
+    DLiteErrMask *_errmaskptr = _dlite_err_mask_get();          \
+    DLiteErrMask _errmask = (_errmaskptr) ? *_errmaskptr : 0;   \
+    dlite_err_mask_set(mask)
+
+#define DLITE_NOERR_END                                         \
+    dlite_err_mask_set(_errmask);                               \
+  } while (0)
+
+
+/** Set whether to ignore printing given error code. */
+void dlite_err_ignored_set(DLiteErrCode code, int value);
+
+/** Return whether printing is ignored for given error code. */
+int dlite_err_ignored_get(DLiteErrCode code);
+
+
 #ifndef __GNUC__
 #define __attribute__(x)
 #endif

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -15,7 +15,6 @@
 #include "dlite-misc.h"
 #include "dlite-datamodel.h"
 #include "dlite-storage-plugins.h"
-#include "dlite-errors.h"
 
 #ifdef WITH_PYTHON
 #define NOPYTHON

--- a/src/dlite-storage.c
+++ b/src/dlite-storage.c
@@ -12,7 +12,6 @@
 #include "dlite.h"
 #include "dlite-macros.h"
 #include "dlite-datamodel.h"
-#include "dlite-errors.h"
 #include "dlite-storage-plugins.h"
 #include "getuuid.h"
 

--- a/src/dlite-store.c
+++ b/src/dlite-store.c
@@ -6,7 +6,6 @@
 #include "utils/err.h"
 #include "dlite-macros.h"
 #include "dlite-store.h"
-#include "dlite-errors.h"
 
 /* TODO
    - Add read and write locks for tread safety they should be local to

--- a/src/dlite-type-cast.c
+++ b/src/dlite-type-cast.c
@@ -17,7 +17,6 @@
 
 #include "dlite-macros.h"
 #include "dlite-type.h"
-#include "dlite-errors.h"
 
 #ifndef MIN
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))

--- a/src/dlite-type.c
+++ b/src/dlite-type.c
@@ -21,7 +21,6 @@
 #include "dlite-entity.h"
 #include "dlite-macros.h"
 #include "dlite-type.h"
-#include "dlite-errors.h"
 
 
 /* Name DLite types */

--- a/src/dlite.h
+++ b/src/dlite.h
@@ -10,7 +10,6 @@
 #define HAVE_DLITE
 #endif
 
-#include "dlite-errors.h"
 #include "dlite-misc.h"
 #include "dlite-type.h"
 #include "dlite-schemas.h"

--- a/src/pyembed/dlite-pyembed.c
+++ b/src/pyembed/dlite-pyembed.c
@@ -23,7 +23,7 @@ static int python_initialized = 0;
 /* Struct correlating Python exceptions with DLite errors */
 typedef struct {
   PyObject *exc;        /* Python exception */
-  DLiteErrors errcode;  /* DLite error */
+  DLiteErrCode errcode;  /* DLite error */
 } ErrorCorrelation;
 
 /* Global state for this module */
@@ -195,7 +195,7 @@ const char *dlite_pyembed_classname(PyObject *cls)
 /*
   Return DLite error code given Python exception type.
  */
-DLiteErrors dlite_pyembed_errcode(PyObject *type)
+DLiteErrCode dlite_pyembed_errcode(PyObject *type)
 {
   const ErrorCorrelation *corr = error_correlations();
   if (!type) return dliteSuccess;
@@ -211,7 +211,7 @@ DLiteErrors dlite_pyembed_errcode(PyObject *type)
   Return Python exception class corresponding to given DLite error code.
   Returns NULL if `code` is zero.
  */
-PyObject *dlite_pyembed_exception(DLiteErrors code)
+PyObject *dlite_pyembed_exception(DLiteErrCode code)
 {
   const ErrorCorrelation *corr = error_correlations();
   if (!code) return NULL;

--- a/src/pyembed/dlite-pyembed.h
+++ b/src/pyembed/dlite-pyembed.h
@@ -43,13 +43,13 @@ const char *dlite_pyembed_classname(PyObject *cls);
 /**
   Return DLite error code given Python exception type.
  */
-DLiteErrors dlite_pyembed_errcode(PyObject *type);
+DLiteErrCode dlite_pyembed_errcode(PyObject *type);
 
 /**
   Return Python exception class corresponding to given DLite error code.
   Returns NULL if `code` is zero.
  */
-PyObject *dlite_pyembed_exception(DLiteErrors code);
+PyObject *dlite_pyembed_exception(DLiteErrCode code);
 
 /**
   Writes Python error message to `errmsg` (of length `len`) if an

--- a/src/pyembed/dlite-python-singletons.c
+++ b/src/pyembed/dlite-python-singletons.c
@@ -126,7 +126,7 @@ PyObject *dlite_python_module_class(const char *classname)
   Help function returning builtin Python exception corresponding to
   error code or NULL, if no such built-in exception exists in Python.
  */
-static PyObject *_python_exc(DLiteErrors code)
+static PyObject *_python_exc(DLiteErrCode code)
 {
   switch (code) {
   case dliteIOError:                return PyExc_IOError;
@@ -164,7 +164,7 @@ static PyObject *_python_exc(DLiteErrors code)
 
   Returns NULL if `code` is equal or smaller than `dliteLastError`.
 */
-PyObject *dlite_python_module_error(DLiteErrors code)
+PyObject *dlite_python_module_error(DLiteErrCode code)
 {
   PyObject *dict, *exc, *pyexc, *dliteError, *base;
   const char *errdescr;

--- a/src/pyembed/dlite-python-singletons.h
+++ b/src/pyembed/dlite-python-singletons.h
@@ -59,7 +59,7 @@ PyObject *dlite_python_module_class(const char *classname);
 
   Returns NULL if `code` is out of range.
 */
-PyObject *dlite_python_module_error(DLiteErrors code);
+PyObject *dlite_python_module_error(DLiteErrCode code);
 
 
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(dlite-src-tests C)
 
 set(tests
   test_misc
+  test_errors
   test_type
   test_storage
   test_entity

--- a/src/tests/test_errors.c
+++ b/src/tests/test_errors.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+
+#include "minunit/minunit.h"
+#include "dlite.h"
+
+
+MU_TEST(test_errcode)
+{
+  mu_assert_int_eq(dliteIndexError, dlite_errcode("DLiteIndexError"));
+  mu_assert_int_eq(dliteIndexError, dlite_errcode("DLiteIndex..."));
+  mu_assert_int_eq(dliteUnknownError, dlite_errcode("another error..."));
+}
+
+
+
+/***********************************************************************/
+
+
+MU_TEST_SUITE(test_suite)
+{
+  MU_RUN_TEST(test_errcode);
+}
+
+int main()
+{
+  MU_RUN_SUITE(test_suite);
+  MU_REPORT();
+  return (minunit_fail) ? 1 : 0;
+}

--- a/storages/python/python-storage-plugins/postgresql.py
+++ b/storages/python/python-storage-plugins/postgresql.py
@@ -113,10 +113,9 @@ class postgresql(dlite.DLiteStorageBase):
 
         # Make sure we have metadata object correcponding to metaid
         try:
-            with dlite.err():
+            with dlite.errctl(hide=RuntimeError):
                 meta = dlite.get_instance(metaid)
         except RuntimeError:
-            dlite.errclr()
             meta = self.load(metaid)
 
         inst = dlite.Instance.from_metaid(metaid, dims, uri)

--- a/storages/python/tests-python/test_redis.py
+++ b/storages/python/tests-python/test_redis.py
@@ -55,20 +55,19 @@ newinst2 = dlite.Instance.from_location(
 )
 
 
+# Test deleting from Redis
+with dlite.Storage("redis", "localhost", "port=6379;db=13") as s:
+    uuid = save1["uuid"]
+    assert uuid in s.get_uuids()
+    s.delete(save1["uuid"])
+    assert uuid not in s.get_uuids()
+
+
 # Test instance expiration
 print("Wait for instances in redis storage has expired...")
 sleep(1.1)
-
-del newinst1
-try:
-    with dlite.silent:
-        newinst1 = dlite.Instance.from_location(
-            "redis", "localhost", "port=6379;db=13", id=save1["uuid"]
-        )
-except dlite.DLiteError:
-    pass
-else:
-    raise RuntimeError("expected redis storage to have expired")
+with dlite.Storage("redis", "localhost", "port=6379;db=13") as s:
+    assert not s.get_uuids()
 
 
 # Test encryption


### PR DESCRIPTION
# Description
Made it easy to silence specific DLite error messages both in C and Python.

Also renamed `DLiteErrors` to `DLiteErrCode` since it is an error code (or rather a type for an error code) and not a list of possible error codes.

Also fixed an unrelated issue when loading an instance from BSON (needed by the redis plugin).  Now metadata lookup also include the BSON document containing the instance.  Furthermore, the metadata is properly initiated. This also fixes an issue in the redis plugin.

This PR relates to issue #328 

## Type of change
- [x] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [x] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [x] Does this PR close the issue?
- [x] Is the code easy to read and understand?
- [x] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
