### PR TITLE
Update to sphinx-autoapi 3.0

### DIFF
--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,10 +1,11 @@
 importlib-metadata==4.13.0; python_version<'3.8'
-breathe>=4.34.0
+breathe>=4.35.0
 beautifulsoup4>=4.11.1
 lxml>=4.7.1
-myst-nb~=0.17.1
+myst-nb~=0.17.2
 
-Sphinx>=4.5.0,<5
+Sphinx>=4.5.0,<5; python_version<'3.8'
+Sphinx>=6.1.0,<7; python_version>='3.8'
 
 sphinx-autoapi~=2.10; python_version<'3.8'
 sphinx-autoapi~=3.0; python_version>='3.8'
@@ -14,8 +15,6 @@ sphinx-toggleprompt~=0.4.0
 # sphinx-copybutton~=0.5.1  # does not work well with toggleprompt
 sphinx-design~=0.3.0
 sphinxcontrib-plantuml~=0.24
-
-
 
 nbclient<0.6,>=0.2
 docutils<0.18,>=0.14

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -6,7 +6,8 @@ myst-nb~=0.17.1
 
 Sphinx>=4.5.0,<5
 
-sphinx-autoapi~=2.0
+sphinx-autoapi~=2.10; python_version<'3.8'
+sphinx-autoapi~=3.0; python_version>='3.8'
 sphinx-autobuild~=2021.3.14
 sphinx-book-theme~=0.3.3
 sphinx-toggleprompt~=0.4.0


### PR DESCRIPTION
# Description
Note, this is only possible for Python 3.8 and up.

According to [this](https://stackoverflow.com/questions/77257145/sphinx-autoapi-error-module-object-has-no-attribute-doc-with-various-sphi) stackoverflow question, this should be the solution.

Fixes #654.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
