### PR TITLE
Added utility function get_referred_instances()

### DIFF
--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -545,7 +545,7 @@ def get_referred_instances(inst, include_meta=False):
 
     would return the set `{coll, inst1, inst2, inst3, inst4, inst5}`.
 
-    It same set would be returned even if one of the instances would
+    The same set would be returned even if one of the instances would
     have a 'ref' property referring back to 'coll'.
     """
     references = set()

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -539,7 +539,7 @@ def get_referred_instances(inst, include_meta=False):
     -------
     If you have a collection 'coll' with three instances 'inst1',
     'inst2' and 'inst3' and 'inst2' has a 'ref' property, which is
-    an array of 'inst4' and 'inst5', then
+    an array `[inst4, inst5]`, then
 
         get_referred_instances(coll)
 

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -526,7 +526,27 @@ def get_referred_instances(inst, include_meta=False):
     """Return a set with all instances that are directly or indirectly
     referred to by `inst`.
 
+    This function follows instances referred to by collections and via
+    properties of type 'ref'.  Transaction parents are not included,
+    hence the returned set only includes instances in the current
+    snapshot.
+
+    Cyclic references are handled correctly.
+
     If `include_meta` is true, also return metadata.
+
+    Example
+    -------
+    If you have a collection 'coll' with three instances 'inst1',
+    'inst2' and 'inst3' and 'inst2' has a 'ref' property, which is
+    an array of 'inst4' and 'inst5', then
+
+        get_referred_instances(coll)
+
+    would return the set `{coll, inst1, inst2, inst3, inst4, inst5}`.
+
+    It same set would be returned even if one of the instances would
+    have a 'ref' property referring back to 'coll'.
     """
     references = set()
     _get_referred_instances(inst, include_meta, references)

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -516,7 +516,42 @@ def infer_dimensions(meta, values, strict=True):
         missing_dims = dimnames.difference(dims.keys())
         raise CannotInferDimensionError(
             f"insufficient number of properties provided to infer dimensions: "
-            f"{missing_dims}"
+            f"{missing_dims} for metadata: {meta.uri}"
         )
 
     return dims
+
+
+def get_referred_instances(inst, include_meta=False):
+    """Return a set with all instances that are directly or indirectly
+    referred to by `inst`.
+
+    If `include_meta` is true, also return metadata.
+    """
+    references = set()
+    _get_referred_instances(inst, include_meta, references)
+    return references
+
+
+def _get_referred_instances(inst, include_meta, references):
+    """Recursive help function for get_referred_instances()."""
+    if inst is None or inst in references:
+        return
+    references.add(inst)
+    if isinstance(inst, dlite.Collection):
+        for i in inst.get_instances():
+            _get_referred_instances(i, include_meta, references)
+    else:
+        for prop in inst.meta.properties["properties"]:
+            if prop.type == "ref":
+                if prop.ndims:
+                    for i in inst[prop.name]:
+                        _get_referred_instances(
+                            i, include_meta, references
+                        )
+                else:
+                        _get_referred_instances(
+                            inst[prop.name], include_meta, references
+                        )
+    if include_meta:
+        _get_referred_instances(inst.meta, include_meta, references)


### PR DESCRIPTION
# Description
Added new utility function get_referred_instances() that recursively finds all instances that are directly or indirectly referred to by an instance (e.g. a collection or a reference property).

Needed by Musicode demo.

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
