### PR TITLE
Ensure that only metadata is callable

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -50,6 +50,45 @@ class Metadata(Instance):
     def __repr__(self):
         return f"<Metadata: uri='{self.uri}'>"
 
+    def __call__(self, dimensions=(), properties=None, id=None, dims=None):
+        """Returns a new instance of this metadata.
+
+        By default the instance is uninitialised, but with the `properties`
+        argument it can be either partly or fully initialised.
+
+        Arguments:
+            dimensions: Either a dict mapping dimension names to values or
+                a sequence of dimension values.
+            properties: Dict of property name-property value pairs.  Used
+                to initialise the instance (fully or partly).  A KeyError
+                is raised if a key is not a valid property name.
+            id: Id of the new instance.  The default is to create a
+                random UUID.
+            dims: Deprecated alias for `dimensions`.
+
+        Returns:
+            New instance.
+        """
+        if not self.is_meta:
+            raise TypeError('data instances are not callable')
+        if dims is not None:
+            warnings.warn(
+                "`dims` argument of metadata constructor is deprecated.\n"
+                "Use `dimensions` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            dimensions = dims
+        if isinstance(dimensions, dict):
+            dimnames = [d.name for d in self.properties['dimensions']]
+            dimensions = [dimensions[name] for name in dimnames]
+
+        inst = Instance.from_metaid(self.uri, dimensions, id)
+        if isinstance(properties, dict):
+            for k, v in properties.items():
+                inst[k] = v
+        return inst
+
     def getprop(self, name):
         """Returns the metadata property object with the given name."""
         if "properties" not in self.properties:
@@ -607,45 +646,6 @@ def get_instance(id: str, metaid: str = None, check_storages: bool = True) -> "I
             None,
             iterfun(self),
         )
-
-    def __call__(self, dimensions=(), properties=None, id=None, dims=None):
-        """Returns a new instance of this metadata.
-
-        By default the instance is uninitialised, but with the `properties`
-        argument it can be either partly or fully initialised.
-
-        Arguments:
-            dimensions: Either a dict mapping dimension names to values or
-                a sequence of dimension values.
-            properties: Dict of property name-property value pairs.  Used
-                to initialise the instance (fully or partly).  A KeyError
-                is raised if a key is not a valid property name.
-            id: Id of the new instance.  The default is to create a
-                random UUID.
-            dims: Deprecated alias for `dimensions`.
-
-        Returns:
-            New instance.
-        """
-        if not self.is_meta:
-            raise TypeError('data instances are not callable')
-        if dims is not None:
-            warnings.warn(
-                "`dims` argument of metadata constructor is deprecated.\n"
-                "Use `dimensions` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            dimensions = dims
-        if isinstance(dimensions, dict):
-            dimnames = [d.name for d in self.properties['dimensions']]
-            dimensions = [dimensions[name] for name in dimnames]
-
-        inst = Instance.from_metaid(self.uri, dimensions, id)
-        if isinstance(properties, dict):
-            for k, v in properties.items():
-                inst[k] = v
-        return inst
 
     def asdict(self, soft7=True, uuid=True):
         """Returns a dict representation of self.

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -283,9 +283,10 @@ if HAVE_PYTEST:
     with pytest.raises(AttributeError):
         prop.ndims = 10
 
-del inst
-del e2
-del e3
+
+# Test that metadata is callable, but not instances
+assert callable(inst.meta)
+assert not callable(inst)
 
 
 # Metadata schema


### PR DESCRIPTION
# Description
The `__call__()` method only applies to metadata, so moved it from Instance to Metadata.

Fixes the issue with `TypeError: data instances are not callable` in the Musicode demo.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
