### PR TITLE
Make dlite.Instance.copy() return the correct type

### DIFF
--- a/bindings/python/dlite-collection-python.i
+++ b/bindings/python/dlite-collection-python.i
@@ -169,7 +169,12 @@ class Collection(Instance):
         of `metaid` using instance mappings.  If no such instance mapping
         is registered, a DLiteError is raised.
         """
-        return _collection_get_new(self._coll, label, metaid)
+        inst = _collection_get_new(self._coll, label, metaid)
+        if inst.is_meta:
+            inst.__class__ = Metadata
+        elif inst.meta.uri == COLLECTION_ENTITY:
+            inst.__class__ = Collection
+        return inst
 
     def get_id(self, id):
         """Return instance with given id."""

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -639,6 +639,17 @@ def get_instance(id: str, metaid: str = None, check_storages: bool = True) -> "I
     def __str__(self):
         return self.asjson()
 
+    def copy(self, newid=None):
+        """Returns a copy of this instance.  If `newid` is given, it
+        will be the id of the new instance, otherwise it will be given
+        a random UUID."""
+        newinst = self._copy(newid=newid)
+        if newinst.is_meta:
+            newinst.__class__ = Metadata
+        elif newinst.meta.uri == COLLECTION_ENTITY:
+            newinst.__class__ = Collection
+        return newinst
+
     def __reduce__(self):
         # ensures that instances can be pickled
         def iterfun(inst):

--- a/bindings/python/dlite-entity.i
+++ b/bindings/python/dlite-entity.i
@@ -476,9 +476,9 @@ Call signatures:
   %feature("docstring",
            "Returns a copy of the instance.  If `newid` is given, it will be\n"
            "the id of the new instance, otherwise it will be given a\n"
-           "random UUID.") copy;
-  %newobject copy;
-  struct _DLiteInstance *copy(const char *newid=NULL) {
+           "random UUID.") _copy;
+  %newobject _copy;
+  struct _DLiteInstance *_copy(const char *newid=NULL) {
     return dlite_instance_copy($self, newid);
   }
 

--- a/bindings/python/tests/test_collection.py
+++ b/bindings/python/tests/test_collection.py
@@ -115,6 +115,11 @@ assert rel.o == "http://onto-ns.com/meta/0.1/MyEntity"
 (i1,) = coll.get_instances()
 assert i1 == inst1
 
+
+# Test that coll.copy() is a collection
+newcoll = coll.copy()
+assert isinstance(newcoll, dlite.Collection)
+
 # We have no collections in the collection
 assert not list(coll.get_instances(metaid=dlite.COLLECTION_ENTITY))
 

--- a/bindings/python/tests/test_collection.py
+++ b/bindings/python/tests/test_collection.py
@@ -116,10 +116,6 @@ assert rel.o == "http://onto-ns.com/meta/0.1/MyEntity"
 assert i1 == inst1
 
 
-# Test that coll.copy() is a collection
-newcoll = coll.copy()
-assert isinstance(newcoll, dlite.Collection)
-
 # We have no collections in the collection
 assert not list(coll.get_instances(metaid=dlite.COLLECTION_ENTITY))
 
@@ -149,6 +145,18 @@ assert list(coll.get_objects()) == [
     inst1.uuid,
     inst1.meta.uri,
 ]
+
+
+# Test that coll.copy() is a collection
+newcoll = coll.copy()
+assert isinstance(newcoll, dlite.Collection)
+
+# Test Collection.get() returns the right Instance subclass
+coll.add("newcoll", newcoll)
+coll.add("meta", newcoll.meta)
+assert isinstance(coll["inst1"], dlite.Instance)
+assert isinstance(coll["newcoll"], dlite.Collection)
+assert isinstance(coll["meta"], dlite.Metadata)
 
 
 # String representation

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -169,6 +169,17 @@ else:
     assert False  # missing dimensions should raise an exception
 
 
+# Test copy
+newinst = inst.copy()
+assert isinstance(newinst, dlite.Instance)
+assert newinst.dimensions == inst.dimensions
+for newprop, prop in zip(newinst.properties, inst.properties):
+    assert np.all(newprop == prop)
+
+newmeta = inst.meta.copy()
+assert isinstance(newmeta, dlite.Metadata)
+
+
 # Check pickling
 s = pickle.dumps(inst)
 inst3 = pickle.loads(s)


### PR DESCRIPTION
# Description
Ensure that the instance returned by `dlite.Instance.copy()` has the right class.

Also applied the same fix to `dlite.Collection.get()`.

Needed by the Musicode demo.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
