### PR TITLE
Fixed segfault caused by misspelled shape

### DIFF
--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -312,3 +312,15 @@ schema.meta.save("basic_metadata_schema.json?mode=w;arrays=false")
 
 mm = dlite.Instance.from_url("json://entity_schema.json")
 assert mm.uri == dlite.ENTITY_SCHEMA
+
+
+# Test loading invalid json input
+with dlite.errctl(hide=True):
+    Invalid1 = dlite.get_instance("http://onto-ns.com/meta/0.1/Invalid1")
+with raises(dlite.DLiteMissingInstanceError, dlite.DLiteSyntaxError):
+    invalid1 = Invalid1([2], properties={"name": "a", "f": [3.14, 2.72]})
+
+# For issue #686
+Invalid2 = dlite.get_instance("http://onto-ns.com/meta/0.1/Invalid2")
+with raises(dlite.DLiteMissingInstanceError, dlite.DLiteSyntaxError):
+    invalid2 = Invalid2([2])

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -579,8 +579,10 @@ static int dlite_instance_free(DLiteInstance *inst)
           size_t n, nmemb=1;
           for (j=0; j<p->ndims; j++)
             nmemb *= DLITE_PROP_DIM(inst, i, j);
-          for (n=0; n<nmemb; n++)
-            dlite_type_clear(*(char **)ptr + n*p->size, p->type, p->size);
+          for (n=0; n<nmemb; n++) {
+            void *memptr = *(char **)ptr;
+            if (memptr) dlite_type_clear(memptr + n*p->size, p->type, p->size);
+          }
         }
         free(*(void **)ptr);
       } else {

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -577,12 +577,12 @@ static int dlite_instance_free(DLiteInstance *inst)
         if (dlite_type_is_allocated(p->type)) {
           int j;
           size_t n, nmemb=1;
+          char *memptr = *(char **)ptr;
           for (j=0; j<p->ndims; j++)
             nmemb *= DLITE_PROP_DIM(inst, i, j);
-          for (n=0; n<nmemb; n++) {
-            void *memptr = *(char **)ptr;
-            if (memptr) dlite_type_clear(memptr + n*p->size, p->type, p->size);
-          }
+          if (memptr)
+            for (n=0; n<nmemb; n++)
+              dlite_type_clear(memptr + n*p->size, p->type, p->size);
         }
         free(*(void **)ptr);
       } else {


### PR DESCRIPTION
# Description
#closes #686

I comment on the fix here to avoid clutter the code with too many comments.

**Short motivation for the change in dlite-entity.c**:
-  `memptr` points to the start of the memory segment of the array data
-  if `memptr` is NULL, the array has not been allocated and there is nothing to free (trying to free it will cause segfault)
- the if statement on line 583 ensures that dlite_type_clear() is only called when there is something to free

The reason that a misspelled shape name results in `memptr` being NULL is that `_instance_propdims_eval()` (dlite-entity.c:455) will fail. This will jump directly to line 495 where the refcount of the instance we are trying to create will be decerased. Since this refcount is already zero, `dlite_instance_free()` will be called with a partly instantiated instance.

**NOTE**: This PR builds on top of PR #687. Merge that PR first.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
