### PR TITLE
Added uninstall cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,3 +829,15 @@ if(CROSS_TARGET)
     DESTINATION "lib"
     )
 endif()
+
+
+# Uninstall
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/uninstall.cmake)
+endif()

--- a/cmake/uninstall.cmake.in
+++ b/cmake/uninstall.cmake.in
@@ -1,0 +1,24 @@
+# Implements "uninstall" make target
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR
+    "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt"
+  )
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else()
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/cmake/uninstall.cmake.in
+++ b/cmake/uninstall.cmake.in
@@ -1,4 +1,7 @@
 # Implements "uninstall" make target
+#
+# See https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+#
 if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
   message(FATAL_ERROR
     "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt"


### PR DESCRIPTION
# Description
Added a uninstall cmake target, making it easy to uninstall dlite when it is installed with cmake. Just do

    make uninstall

or with cmake

    cmake --build . --target uninstall

This is simply a slightly adapted copy of the recipe from the public cmake documentation: https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
