### PR TITLE
Automatic detect virtualenv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,38 @@ if(WITH_PYTHON)
     set(Python3_USE_STATIC_LIBS TRUE)
   endif()
 
+  #
+  if(DEFINED ENV{VIRTUAL_ENV})
+    message(STATUS "Detected virtual environment $ENV{VIRTUAL_ENV}")
+
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+      message(STATUS "Setting CMAKE_INSTALL_PREFIX=$ENV{VIRTUAL_ENV}")
+      set(CMAKE_INSTALL_PREFIX "$ENV{VIRTUAL_ENV}" CACHE
+        PATH "Install path prefix, prepended onto install directories." FORCE)
+    endif()
+
+    if(NOT Python3_FIND_VIRTUALENV)
+      message(STATUS "Setting Python3_FIND_VIRTUALENV=ONLY")
+      set(Python3_FIND_VIRTUALENV=ONLY)
+    endif()
+
+    if(NOT PYTHON_VERSION)
+      find_program(
+        python_exe
+        python
+        PATHS $ENV{VIRTUAL_ENV}/bin
+        REQUIRED
+        NO_DEFAULT_PATH
+      )
+      execute_process(
+        COMMAND ${python_exe} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}', end='')"
+        OUTPUT_VARIABLE pyversion
+      )
+      message(STATUS "Setting PYTHON_VERSION=${pyversion}")
+      set(PYTHON_VERSION "${pyversion}")
+    endif()
+  endif()
+
   # Find Python package
   set(CMAKE_CROSSCOMPILING_EMULATOR ${RUNNER})
   if (PYTHON_VERSION)


### PR DESCRIPTION
# Description
Simplified building DLite by updating CMake to automatically detect if DLite is build within a virtual Python environment.
In that case, set the following configurations (if they are not already provided on the command line):

    CMAKE_INSTALL_PREFIX
    Python3_FIND_VIRTUALENV
    PYTHON_VERSION

**Installation with virtualenvwrapper**:

    mkvirtualenv newenv
    mkdir build-newenv
    cd build-newenv
    cmake ..
    make -j4 install

    # deactivate/reactivate environment to get LD_LIBRARY_PATH set correctly before testing
    deactivate
    workon newenv

    ctest -j4 -E static-code-analysis

**Installation with standard Python virtualenv**:

    python -m venv ~/.envs/newenv
    mkdir build-newenv
    cd build-newenv
    cmake ..
    make -j4 install

    # deactivate/reactivate environment to get LD_LIBRARY_PATH set correctly before testing
    deactivate
    . ~/.envs/newenv/activate

    ctest -j4 -E static-code-analysis
    

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
