### PR TITLE
Do not free the librdf world if called from atexit handler.

### DIFF
--- a/src/triplestore-redland.c
+++ b/src/triplestore-redland.c
@@ -98,8 +98,6 @@ static int logger(void *user_data, librdf_log_message *message)
   //librdf_log_facility level = librdf_log_message_facility(message);
   UNUSED(user_data);
 
-  fprintf(stderr, "\n*** logger: %s\n", msg);  // XXX
-
   switch (level) {
   case LIBRDF_LOG_NONE: return 0;
   case LIBRDF_LOG_DEBUG: warnx("DEBUG: %s", msg); break;
@@ -116,7 +114,7 @@ static void finalize_check()
 {
   Globals *g = get_globals();
   if (g->finalize_pending && g->nmodels == 0 && g->default_world) {
-    librdf_free_world(g->default_world);
+    if (!dlite_globals_in_atexit()) librdf_free_world(g->default_world);
     g->default_world = NULL;
     g->finalize_pending = 0;
   }


### PR DESCRIPTION
# Description
Do not free the librdf world if called from atexit handler.

This may avoid a segfault due to inconsistent state during termination. It is not possible to add a test for this because it depends on the order that the operating system is freeing resources.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
