### PR TITLE
Fix typo in CMakeLists.txt when installing dlite-validate

### DIFF
--- a/bindings/python/scripts/CMakeLists.txt
+++ b/bindings/python/scripts/CMakeLists.txt
@@ -23,7 +23,7 @@ install(
   CODE "
    execute_process(
      COMMAND ${Python3_EXECUTABLE} -m pip install
-       --prefix=${CMAKE_INSTALL_PREFIX} --force
+       --prefix=${CMAKE_INSTALL_PREFIX} --force .
      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
    )"
 )


### PR DESCRIPTION
# Description
Fix typo in CMakeLists.txt when installing dlite-validate

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
