### PR TITLE
WIP: Fix segfaults

### DIFF
--- a/bindings/python/dlite-misc-python.i
+++ b/bindings/python/dlite-misc-python.i
@@ -4,6 +4,11 @@
 
 %pythoncode %{
 
+import atexit
+
+atexit.register(_mark_python_atexit)
+
+
 class errctl():
     """Context manager for temporary disabling specific DLite error
     messages or redirecting them.

--- a/bindings/python/dlite-misc.i
+++ b/bindings/python/dlite-misc.i
@@ -130,6 +130,13 @@ int globmatch(const char *pattern, const char *s);
 
 
 %feature("docstring", "\
+Tell DLite that we are in a Python atexit handler.
+") _mark_python_atexit;
+%rename(_mark_python_atexit) dlite_globals_set_atexit;
+void dlite_globals_set_atexit(void);
+
+
+%feature("docstring", "\
 Clear the last error (setting its error code to zero).
 ") dlite_errclr;
 void dlite_errclr(void);

--- a/src/dlite-misc.c
+++ b/src/dlite-misc.c
@@ -511,9 +511,6 @@ DLiteGlobals *dlite_globals_get(void)
   if (!_globals_handler) {
     _globals_handler = session_get_default();
 
-    /* */
-    UNUSED(get_locals());
-
     /* Make valgrind and other memory leak detectors happy by freeing
        up all globals at exit. */
     atexit(_free_globals);
@@ -556,6 +553,9 @@ void dlite_init(void)
 
   if (!initialized) {
     initialized = 1;
+
+    /* Call get_locals() to ensure that the local state is initialised. */
+    get_locals();
 
     /* Set up global state for utils/err.c */
     if (!dlite_globals_get_state(ERR_STATE_ID))

--- a/src/dlite-misc.h
+++ b/src/dlite-misc.h
@@ -14,11 +14,6 @@
 #define DLITE_UUID_LENGTH 36  /*!< length of an uuid (excl. NUL-termination) */
 
 
-/** Special state id only used to indicate whether we are in an atexit
-    handler or not */
-#define ATEXIT_MARKER_ID "dlite-atexit-marker-id"
-
-
 /**
   @name General dlite utility functions
   @{
@@ -288,6 +283,11 @@ void *dlite_globals_get_state(const char *name);
   Returns non-zero if we are in an atexit handler.
  */
 int dlite_globals_in_atexit(void);
+
+/**
+  Mark that we are in an atexit handler.
+ */
+void dlite_globals_set_atexit(void);
 
 /** @} */
 

--- a/src/dlite-storage.c
+++ b/src/dlite-storage.c
@@ -190,7 +190,8 @@ void dlite_storage_set_idflag(DLiteStorage *s, DLiteIDFlag idflag)
 void *dlite_storage_iter_create(DLiteStorage *s, const char *pattern)
 {
   if (!s->api->iterCreate)
-    return errx(1, "driver '%s' does not support iterCreate()",
+    return errx(dliteUnsupportedError,
+                "driver '%s' does not support iterCreate()",
                 s->api->name), NULL;
   return s->api->iterCreate(s, pattern);
 }
@@ -206,7 +207,8 @@ void *dlite_storage_iter_create(DLiteStorage *s, const char *pattern)
 int dlite_storage_iter_next(DLiteStorage *s, void *iter, char *buf)
 {
   if (!s->api->iterNext)
-    return errx(-1, "driver '%s' does not support iterNext()", s->api->name);
+    return errx(dliteUnsupportedError,
+                "driver '%s' does not support iterNext()", s->api->name);
   return s->api->iterNext(iter, buf);
 }
 
@@ -216,10 +218,11 @@ int dlite_storage_iter_next(DLiteStorage *s, void *iter, char *buf)
 void dlite_storage_iter_free(DLiteStorage *s, void *iter)
 {
   // Do not call iterFree() during atexit(), since it may lead to segfault
-  if (dlite_globals_get_state(ATEXIT_MARKER_ID)) return;
+  if (dlite_globals_in_atexit()) return;
 
   if (!s->api->iterFree)
-    errx(1, "driver '%s' does not support iterFree()", s->api->name);
+    errx(dliteUnsupportedError,
+         "driver '%s' does not support iterFree()", s->api->name);
   else
     s->api->iterFree(iter);
 }

--- a/src/utils/session.c
+++ b/src/utils/session.c
@@ -24,6 +24,7 @@ typedef map_t(State) map_state_t;
 
 struct _Session {
   const char *session_id;
+  int freeing;
   map_state_t states;
 };
 
@@ -56,12 +57,12 @@ Session *session_create(const char *session_id)
   Session s, *sp;
   memset(&s, 0, sizeof(s));
   if (map_get(sessions, session_id))
-    return errx(1, "cannot create new session with existing session id: %s",
+    return errx(-15, "cannot create new session with existing session id: %s",
                 session_id), NULL;
   if (!(s.session_id = strdup(session_id)))
-    return err(1, "allocation failure"), NULL;
+    return err(-12, "allocation failure"), NULL;
   if (map_set(sessions, session_id, s))
-    return errx(1, "failed to create new session with id: %s", session_id), NULL;
+    return errx(-15, "failed to create new session with id: %s", session_id), NULL;
   map_init(&s.states);
 
   sp = map_get(sessions, session_id);
@@ -73,7 +74,7 @@ Session *session_create(const char *session_id)
 }
 
 /*
-  Free all memory associated with `session`.
+  Free all memory associated with session `s`.
 */
 void session_free(Session *s)
 {
@@ -81,10 +82,15 @@ void session_free(Session *s)
   map_iter_t iter = map_iter(&s->states);
   const char *name, *id=s->session_id;
 
+  /* Indicate that we are freeing this session. This will avoid crashes in
+     case that free_fun() calls session_add_state().  */
+  s->freeing = 1;
+
   while ((name = map_next(&s->states, &iter))) {
     State *st = map_get(&s->states, name);
     if (st->free_fun) st->free_fun(st->ptr);
   }
+  s->freeing = 0;
   map_deinit(&s->states);
 
   if (id) {
@@ -97,6 +103,7 @@ void session_free(Session *s)
     map_deinit(sessions);
 }
 
+
 /*
   Retrieve session from `session_id`.
 
@@ -106,7 +113,7 @@ Session *session_get(const char *session_id)
 {
   map_session_t *sessions = get_sessions();
   Session *s = map_get(sessions, session_id);
-  if (!s) return errx(1, "no session with id: %s", session_id), NULL;
+  if (!s) return errx(-15, "no session with id: %s", session_id), NULL;
   return s;
 }
 
@@ -120,7 +127,6 @@ const char *session_get_id(Session *s)
 {
   return s->session_id;
 }
-
 
 
 
@@ -153,7 +159,7 @@ int session_set_default(Session *s)
   map_session_t *sessions = get_sessions();
   Session *s2 = map_get(sessions, DEFAULT_SESSION_ID);
   if (s2 && s2 != s)
-    return errx(1, "a default session has already been set");
+    return errx(-3, "a default session has already been set");
   map_set(sessions, DEFAULT_SESSION_ID, *s);
   return 0;
 }
@@ -173,8 +179,11 @@ int session_add_state(Session *s, const char *name, void *ptr,
                            void (*free_fun)(void *ptr))
 {
   State st, *sp;
-  memset(&st, 0, sizeof(st));
 
+  if (s->freeing)
+    return errx(-3, "cannot add state while freeing session");
+
+  memset(&st, 0, sizeof(st));
   st.ptr = ptr;
   st.free_fun = free_fun;
   if (map_get(&s->states, name))
@@ -196,7 +205,7 @@ int session_add_state(Session *s, const char *name, void *ptr,
 int session_remove_state(Session *s, const char *name)
 {
   State *st = map_get(&s->states, name);
-  if (!st) return errx(1, "no such global state: %s", name);
+  if (!st) return errx(-15, "no such global state: %s", name);
   if (st->free_fun) st->free_fun(st->ptr);
   map_remove(&s->states, name);
   return 0;

--- a/src/utils/session.c
+++ b/src/utils/session.c
@@ -15,17 +15,17 @@
 
 
 typedef struct _State {
-  void *ptr;
-  void (*free_fun)(void *ptr);
+  void *ptr;                    // pointer to state
+  void (*free_fun)(void *ptr);  // function for free'ing the state
 } State;
 
 typedef map_t(State) map_state_t;
 
 
 struct _Session {
-  const char *session_id;
-  int freeing;
-  map_state_t states;
+  const char *session_id;  // unique id identifying a session
+  int freeing;             // whether we are freeing this session
+  map_state_t states;      // map state names to states
 };
 
 typedef map_t(Session) map_session_t;

--- a/src/utils/tests/test_session.c
+++ b/src/utils/tests/test_session.c
@@ -39,7 +39,7 @@ MU_TEST(test_default)
 
   Session *s3 = session_create("new-session");
   stat = session_set_default(s3);
-  mu_assert_int_eq(1, stat);
+  mu_assert_int_eq(-3, stat);
 
   session_free(s1);
   session_free(s3);


### PR DESCRIPTION
# Description
This PR adds a set of fixes to avoid segfaults:
  - avoid crash if session_add_state() is called while freeing a session (this can happen if the free function calls session_add_state())
  - interpret when Python is shutting down like we are in an atexit handler
  - replaced the (mis)use of ATEXIT_MARKER_ID to set/check whether we are in an atexit handler with two clean function calls: - dlite_globals_set_atexit() - dlite_globals_in_atexit()
  - added a local state in dlite-misc.c
  - improved error codes in dlite-storage.c

This PR applies some of the fixes in PR #667, while trying to avoid the problems. However, not all the fixes in #667 are addressed in this PR, so it is still too early to close #667.


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
