### PR TITLE
Notify the C code when entering a Python atexit handler

### DIFF
--- a/bindings/python/dlite-misc-python.i
+++ b/bindings/python/dlite-misc-python.i
@@ -4,6 +4,11 @@
 
 %pythoncode %{
 
+import atexit
+
+atexit.register(_mark_python_atexit)
+
+
 class errctl():
     """Context manager for temporary disabling specific DLite error
     messages or redirecting them.

--- a/bindings/python/dlite-misc.i
+++ b/bindings/python/dlite-misc.i
@@ -130,6 +130,13 @@ int globmatch(const char *pattern, const char *s);
 
 
 %feature("docstring", "\
+Tell DLite that we are in a Python atexit handler.
+") _mark_python_atexit;
+%rename(_mark_python_atexit) dlite_globals_set_atexit;
+void dlite_globals_set_atexit(void);
+
+
+%feature("docstring", "\
 Clear the last error (setting its error code to zero).
 ") dlite_errclr;
 void dlite_errclr(void);

--- a/src/dlite-misc.c
+++ b/src/dlite-misc.c
@@ -457,6 +457,7 @@ int dlite_add_dll_path(void)
  * Managing global state
  ********************************************************************/
 
+#define ATEXIT_MARKER_ID "atexit-marker-id"
 #define ERR_STATE_ID "err-globals-id"
 #define ERR_MASK_ID "err-ignored-id"
 
@@ -588,6 +589,18 @@ int dlite_globals_in_atexit(void)
   return (dlite_globals_get_state(ATEXIT_MARKER_ID)) ? 0 : 1;
 }
 
+/*
+  Mark that we are in an atexit handler.
+ */
+void dlite_globals_set_atexit(void)
+{
+  static void **dummy_ptr=NULL;
+
+  /* Add an atexit marker used by dlite_blobals_in_atexit().
+     The value of the state is not used. */
+  session_add_state((Session *)_globals_handler, ATEXIT_MARKER_ID,
+                    &dummy_ptr, NULL);
+}
 
 
 /********************************************************************

--- a/src/dlite-misc.h
+++ b/src/dlite-misc.h
@@ -14,11 +14,6 @@
 #define DLITE_UUID_LENGTH 36  /*!< length of an uuid (excl. NUL-termination) */
 
 
-/** Special state id only used to indicate whether we are in an atexit
-    handler or not */
-#define ATEXIT_MARKER_ID "dlite-atexit-marker-id"
-
-
 /**
   @name General dlite utility functions
   @{
@@ -288,6 +283,11 @@ void *dlite_globals_get_state(const char *name);
   Returns non-zero if we are in an atexit handler.
  */
 int dlite_globals_in_atexit(void);
+
+/**
+  Mark that we are in an atexit handler.
+ */
+void dlite_globals_set_atexit(void);
 
 /** @} */
 

--- a/src/dlite-storage.c
+++ b/src/dlite-storage.c
@@ -216,7 +216,7 @@ int dlite_storage_iter_next(DLiteStorage *s, void *iter, char *buf)
 void dlite_storage_iter_free(DLiteStorage *s, void *iter)
 {
   // Do not call iterFree() during atexit(), since it may lead to segfault
-  if (dlite_globals_get_state(ATEXIT_MARKER_ID)) return;
+  if (dlite_globals_in_atexit()) return;
 
   if (!s->api->iterFree)
     errx(1, "driver '%s' does not support iterFree()", s->api->name);


### PR DESCRIPTION
# Description
Mark when entering an Python atexit handler.

While Python is shutting down, it may leave DLite in an inconsistent state. By notify the DLite that we are in an atexit handler, we can skip freeing memory that may cause segmentation fault, without having to bother about memory leaks (since the system is shutting down and all memory will be freed anyway).

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
