### PR TITLE
Added dockerfile for building with Ubuntu and minimal requirements

### DIFF
--- a/cmake/Dockerfile-ubuntu
+++ b/cmake/Dockerfile-ubuntu
@@ -1,5 +1,9 @@
 # -*- Mode: Dockerfile -*-
-# Dockerfile for testing with ubuntu
+# Dockerfile for test building with minimal requirements on Ubuntu.
+#
+# This file was added for reproducing DLite issue #711.  It is
+# currently not used by the test system, but it is kept here for easy
+# checking future Ubuntu-related build issues.
 #
 # Build:
 #

--- a/cmake/Dockerfile-ubuntu
+++ b/cmake/Dockerfile-ubuntu
@@ -1,0 +1,46 @@
+# -*- Mode: Dockerfile -*-
+# Dockerfile for testing with ubuntu
+#
+# Build:
+#
+#     docker build -t dlite-ubuntu -f cmake/Dockerfile-ubuntu .
+#
+# Run:
+#
+#     docker run --rm -it --volume $PWD:/io dlite-ubuntu /bin/bash
+#
+
+FROM ubuntu:latest AS dependencies
+
+WORKDIR /io
+
+RUN apt update --fix-missing
+RUN apt install -y \
+    python3-pip \
+    python3-venv \
+    cmake \
+    swig
+
+RUN mkdir ~/.envs
+RUN python3 -m venv ~/.envs/dlite
+RUN . ~/.envs/dlite/bin/activate
+
+RUN pip3 install -U pip
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY CMakeLists.txt LICENSE README.md .
+COPY python/MANIFEST.in python/pyproject.toml python/setup.py python/.
+COPY bindings bindings
+COPY cmake cmake
+COPY doc doc
+COPY examples examples
+COPY src src
+COPY storages storages
+COPY tools tools
+
+FROM dependencies AS build
+WORKDIR /tmp/build-ubuntu
+RUN cmake -DWITH_HDF5=NO /io
+RUN make install
+RUN ctest


### PR DESCRIPTION
# Description
This PR adds a dockerfile for building with minimal requirements on Ubuntu. All non-skipped tests passes.

The issues in #711 with the tests failing instead of being skipped is not reproduced. This could be due to fixes in DLite applied after the issue was created.

The intention with this PR is simply add the Ubuntu dockerfile such that we have it for testing similar issues in the future. 

Closes #711

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
