### PR TITLE
Improve compiling on Ubuntu

### DIFF
--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -3066,18 +3066,18 @@ static int writedim(int d, char *dest, size_t n, const void **pptr,
   char *sep   = (compact) ? ", " : ",\n        ";
   char *end   = (compact) ? "]"  : "\n      ]";
   if (d < p->ndims) {
-    if ((m = snprintf(dest+N, PDIFF(n, N), start)) < 0) goto fail;
+    if ((m = snprintf(dest+N, PDIFF(n, N), "%s", start)) < 0) goto fail;
     N += m;
     for (i=0; i < dims[d]; i++) {
       if ((m = writedim(d+1, dest+N, PDIFF(n, N), pptr, p, dims,
                         width, prec, flags)) < 0) return -1;
       N += m;
       if (i < dims[d]-1) {
-        if ((m = snprintf(dest+N, PDIFF(n, N), sep)) < 0) goto fail;
+        if ((m = snprintf(dest+N, PDIFF(n, N), "%s", sep)) < 0) goto fail;
         N += m;
       }
     }
-    if ((m = snprintf(dest+N, PDIFF(n, N), end)) < 0) goto fail;
+    if ((m = snprintf(dest+N, PDIFF(n, N), "%s", end)) < 0) goto fail;
     N += m;
   } else {
     if ((m = dlite_type_print(dest+N, PDIFF(n, N), *pptr, p->type, p->size,

--- a/storages/python/tests-python/test_image.py
+++ b/storages/python/tests-python/test_image.py
@@ -1,6 +1,12 @@
+import sys
 from pathlib import Path
 
 import dlite
+
+try:
+    import skimage
+except ImportError:
+    sys.exit(44)  # skip test
 
 
 thisdir = Path(__file__).absolute().parent


### PR DESCRIPTION
# Description
Fixed a few issues when compiling on ubuntu:
- Ensure that the format string of snprintf() is literal (removes a warning)
- Do not test image plugin if scikit-image (skimage) is not installed


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
