### PR TITLE
Revert github download/upload artifacts actions back to v3

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -185,7 +185,7 @@ jobs:
         CIBW_MUSLLINUX_I686_IMAGE: ${{ env.CONTAINER_REGISTRY }}/sintef/dlite-python-musllinux_1_1_i686:latest
 
     - name: Store wheels for publishing
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: wheelhouse/*.whl
@@ -227,7 +227,7 @@ jobs:
       run: python -m build --no-isolation --sdist python
 
     - name: Store sdist for publishing
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: sdist
         path: python/dist/*
@@ -239,7 +239,7 @@ jobs:
 
     steps:
     - name: Retrieve wheels and sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         path: dist
 


### PR DESCRIPTION
# Description
Dependabot PRs #746 and #747 bumped up version of the GitHub download-artifact and upload-artifact actions from v3 to v4. After that releasing to PyPI stopped working.

Trying to revert back to v3 to see if we can get releasing to PyPI working again.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

