### PR TITLE
Corrected syntactic check of id's and uuid's

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -182,7 +182,7 @@ jobs:
         CIBW_MUSLLINUX_I686_IMAGE: ${{ env.CONTAINER_REGISTRY }}/sintef/dlite-python-musllinux_1_1_i686:latest
 
     - name: Store wheels for publishing
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: wheels
         path: wheelhouse/*.whl
@@ -224,7 +224,7 @@ jobs:
       run: python -m build --no-isolation --sdist python
 
     - name: Store sdist for publishing
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sdist
         path: python/dist/*
@@ -236,7 +236,7 @@ jobs:
 
     steps:
     - name: Retrieve wheels and sdist
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: dist
 

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -139,7 +139,11 @@ def standardise(v, prop, asdict=False):
         return conv(v)
 
 
-def get_instance(id: str, metaid: str = None, check_storages: bool = True) -> "Instance":
+def get_instance(
+    id: str,
+    metaid: str = None,
+    check_storages: bool = True
+) -> "Instance":
     """Return instance with given id.
 
     Arguments:

--- a/bindings/python/dlite-misc-python.i
+++ b/bindings/python/dlite-misc-python.i
@@ -67,12 +67,13 @@ class errctl():
         """Return sequence of exceptions/exception names as a sequence of
         DLite error coces.  `seq` may also be a single exception or name."""
         sequence = [seq] if isinstance(seq, (str, type)) else seq
-        return [
-            _dlite._err_getcode(
-                exc.__name__ if isinstance(exc, type) else str(exc)
-            )
+        errnames = [
+            exc.__name__ if isinstance(exc, type) else str(exc)
             for exc in sequence
         ]
+        if "DLiteError" in errnames:
+            return [-i for i in range(1, _dlite._get_number_of_errors())]
+        return [_dlite._err_getcode(errname) for errname in errnames]
 
 
 silent = errctl(filename="None")

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -168,7 +168,7 @@ static DLiteInstance *_instance_store_get(const char *id)
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
   DLiteInstance **instp;
-  if ((uuidver = dlite_get_uuid(uuid, id)) != 0 && uuidver != 5)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
     return errx(dliteValueError,
                 "id '%s' is neither a valid UUID or a convertable string",
                 id), NULL;
@@ -738,12 +738,14 @@ DLiteInstance *dlite_instance_get(const char *id)
       break;
     ErrEnd;
     if (s) {
+
       /* url is a storage we can open... */
       ErrTry:
         inst = _instance_load_casted(s, id, NULL, 0);
       ErrCatch(dliteStorageLoadError):  // suppressed error
         break;
       ErrEnd;
+
       dlite_storage_close(s);
     } else {
       /* ...otherwise it may be a glob pattern */
@@ -941,15 +943,18 @@ DLiteInstance *_instance_load_casted(const DLiteStorage *s, const char *id,
   }
 
   /* ...otherwise give up */
-  if (!meta) FAILCODE1(dliteMissingMetadataError, "cannot load metadata: %s", uri);
+  if (!meta) FAILCODE1(dliteMissingMetadataError,
+                       "cannot load metadata: %s", uri);
 
   /* Make sure that metadata is initialised */
   if (dlite_meta_init(meta)) goto fail;
 
   /* check metadata uri */
   if (strcmp(uri, meta->uri) != 0)
-    FAILCODE3(dliteMissingMetadataError, "metadata uri (%s) does not correspond to that in storage (%s): %s",
-	  meta->uri, uri, s->location);
+    FAILCODE3(dliteMissingMetadataError,
+              "metadata uri (%s) does not correspond to that in storage "
+              "(%s): %s",
+              meta->uri, uri, s->location);
 
   /* read dimensions */
   dlite_datamodel_resolve_dimensions(d, meta);

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -168,7 +168,7 @@ static DLiteInstance *_instance_store_get(const char *id)
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
   DLiteInstance **instp;
-  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == UUID_RANDOM)
     return errx(dliteValueError,
                 "id '%s' is neither a valid UUID or a convertable string",
                 id), NULL;

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -185,7 +185,7 @@ const DLiteStoragePlugin *dlite_storage_plugin_get(const char *name)
                       "   DLITE_STORAGE_PLUGIN_DIRS or "
                       "DLITE_PYTHON_STORAGE_PLUGIN_DIRS\n"
                       "   environment variables set?", submsg);
-    errx(1, "%s", buf);
+    errx(dliteStorageOpenError, "%s", buf);
 #endif
     free(buf);
 

--- a/src/dlite-store.c
+++ b/src/dlite-store.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "utils/err.h"
+#include "getuuid.h"
 #include "dlite-macros.h"
 #include "dlite-store.h"
 
@@ -142,7 +143,7 @@ DLiteInstance *dlite_store_pop(DLiteStore *store, const char *id)
   DLiteInstance *inst;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == UUID_RANDOM)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&store->map, uuid)))
     FAIL1("id '%s' is not in store", id);
@@ -164,7 +165,7 @@ DLiteInstance *dlite_store_pop_all(DLiteStore *store, const char *id)
   DLiteInstance *inst;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == UUID_RANDOM)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&store->map, uuid)))
     FAIL1("id '%s' is not in store", id);
@@ -191,7 +192,7 @@ int dlite_store_remove(DLiteStore *store, const char *id)
   item_t *item;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == UUID_RANDOM)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&store->map, uuid))) return 1;
 
@@ -213,7 +214,7 @@ DLiteInstance *dlite_store_get(const DLiteStore *store, const char *id)
   item_t *item;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == UUID_RANDOM)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&((DLiteStore *)store)->map, uuid)))
     FAIL1("id '%s' not in store", id);

--- a/src/dlite-store.c
+++ b/src/dlite-store.c
@@ -142,7 +142,7 @@ DLiteInstance *dlite_store_pop(DLiteStore *store, const char *id)
   DLiteInstance *inst;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) != 0 && uuidver != 5)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&store->map, uuid)))
     FAIL1("id '%s' is not in store", id);
@@ -164,7 +164,7 @@ DLiteInstance *dlite_store_pop_all(DLiteStore *store, const char *id)
   DLiteInstance *inst;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) != 0 && uuidver != 5)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&store->map, uuid)))
     FAIL1("id '%s' is not in store", id);
@@ -191,7 +191,7 @@ int dlite_store_remove(DLiteStore *store, const char *id)
   item_t *item;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) != 0 && uuidver != 5)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&store->map, uuid))) return 1;
 
@@ -213,7 +213,7 @@ DLiteInstance *dlite_store_get(const DLiteStore *store, const char *id)
   item_t *item;
   int uuidver;
   char uuid[DLITE_UUID_LENGTH+1];
-  if ((uuidver = dlite_get_uuid(uuid, id)) != 0 && uuidver != 5)
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0 || uuidver == 4)
     FAIL1("id '%s' is neither a valid UUID or a convertable string", id);
   if (!(item = (item_t *)map_get(&((DLiteStore *)store)->map, uuid)))
     FAIL1("id '%s' not in store", id);

--- a/src/tests/test_getuuid.c
+++ b/src/tests/test_getuuid.c
@@ -34,9 +34,22 @@ MU_TEST(test_isinstanceiri)
   mu_assert_int_eq(  // no colon in URI
     0, isinstanceuri("http//onto-ns.com/meta/0.1/Entity/"
                      "a58d4302-c9be-416d-a36c-cb25524a5a17", 0));
-  mu_assert_int_eq(  // characters after the hash
-    0, isinstanceuri("http://onto-ns.com/meta/0.1/Entity/"
-                     "a58d4302-c9be-416d-a36c-cb25524a5a17#x", 0));
+  mu_assert_int_eq(  // no UUID
+    0, isinstanceuri("http://onto-ns.com/meta/0.1/Entity", 0));
+  mu_assert_int_eq(  // no UUID
+    0, isinstanceuri("http://onto-ns.com/meta/0.1/Entity/", 0));
+
+  char *iri =
+    "http://onto-ns.com/meta/0.1/Entity/a58d4302-c9be-416d-a36c-cb25524a5a17#x";
+  mu_assert_int_eq(0, isinstanceuri(iri, 0));  // characters after the hash
+  mu_assert_int_eq(1, isinstanceuri(iri, strlen(iri)-2));
+
+  mu_assert_int_eq(
+    1, isinstanceuri("http://onto-ns.com/meta/calm/0.1/Chemistry/"
+                     "c1eb2ab7-3fac-538b-b6f0-db2bf6530c92", 0));
+  mu_assert_int_eq(
+    0, isinstanceuri("http://onto-ns.com/meta/calm/0.1/Chemistry/aa6060", 0));
+  mu_assert_int_eq(0, isinstanceuri("aa6060", 0));
 }
 
 MU_TEST(test_getuuid)
@@ -53,18 +66,28 @@ MU_TEST(test_getuuid)
   mu_assert_string_eq("d683cdda-4987-48a5-9e32-cb37adfe3db0", buf);
 
   char *uri;
-  uri = "http://onto-ns.com/meta/0.1/Energy/"
-    "d683cdda-4987-48a5-9e32-cb37adfe3db0";
+  uri =
+    "http://onto-ns.com/meta/0.1/Energy/d683cdda-4987-48a5-9e32-cb37adfe3db0";
   mu_assert_int_eq(UUID_EXTRACT, getuuid(buf, uri));
   mu_assert_string_eq("d683cdda-4987-48a5-9e32-cb37adfe3db0", buf);
-  uri = "http://onto-ns.com/meta/0.1/Energy/"
-    "d683cdda-4987-48a5-9e32-cb37adfe3db0#";
+
+  uri =
+    "http://onto-ns.com/meta/0.1/Energy/d683cdda-4987-48a5-9e32-cb37adfe3db0#";
   mu_assert_int_eq(UUID_EXTRACT, getuuid(buf, uri));
   mu_assert_string_eq("d683cdda-4987-48a5-9e32-cb37adfe3db0", buf);
 
   mu_assert_int_eq(UUID_HASH,
+                   getuuid(buf, "http://onto-ns.com/meta/0.1/Energy"));
+  mu_assert_int_eq(1, isuuid(buf));
+
+  mu_assert_int_eq(UUID_HASH,
+                   getuuid(buf, "http://onto-ns.com/meta/0.1/Energy/inst_id"));
+  mu_assert_int_eq(1, isuuid(buf));
+
+  mu_assert_int_eq(UUID_HASH,
                    getuuid(buf, "?683cdda-4987-48a5-9e32-cb37adfe3db0"));
   mu_assert_int_eq(1, isuuid(buf));
+
   mu_assert_int_eq(UUID_HASH,
                    getuuid(buf, "abc"));
   mu_assert_int_eq(1, isuuid(buf));

--- a/storages/json/dlite-json-storage.c
+++ b/storages/json/dlite-json-storage.c
@@ -11,6 +11,7 @@
 #include "utils/strtob.h"
 #include "utils/jstore.h"
 #include "utils/map.h"
+#include "getuuid.h"
 #include "dlite.h"
 #include "dlite-storage-plugins.h"
 #include "dlite-macros.h"
@@ -233,7 +234,7 @@ DLiteInstance *json_load(const DLiteStorage *s, const char *id)
             "than one instance: %s", s->location);
     }
     if (jstore_iter_deinit(&iter)) goto fail;
-  } else if ((uuidver = dlite_get_uuid(uuid, id)) >= 0 && uuidver != 4) {
+  } else if ((uuidver = dlite_get_uuid(uuid, id)) >= 0 && uuidver != UUID_RANDOM) {
     buf = jstore_get(js->jstore, uuid);
   }
   if (!buf && !(buf = jstore_get(js->jstore, id)))

--- a/storages/json/dlite-json-storage.c
+++ b/storages/json/dlite-json-storage.c
@@ -215,6 +215,7 @@ DLiteInstance *json_load(const DLiteStorage *s, const char *id)
   DLiteJsonStorage *js = (DLiteJsonStorage *)s;
   const char *buf=NULL, *scanid;
   char uuid[DLITE_UUID_LENGTH+1];
+  int uuidver;
 
   if (!js->jstore)
     FAILCODE1(dliteStorageLoadError,
@@ -232,7 +233,7 @@ DLiteInstance *json_load(const DLiteStorage *s, const char *id)
             "than one instance: %s", s->location);
     }
     if (jstore_iter_deinit(&iter)) goto fail;
-  } else if (dlite_get_uuid(uuid, id) == 5) {
+  } else if ((uuidver = dlite_get_uuid(uuid, id)) >= 0 && uuidver != 4) {
     buf = jstore_get(js->jstore, uuid);
   }
   if (!buf && !(buf = jstore_get(js->jstore, id)))


### PR DESCRIPTION
# Description
Corrected syntactic check of id's and uuid's. 

Also rewrote error handling of the return value of  `getuuid()` to correctly handle the new `UUID_EXTRACT` return value. If `getuuid()` can interpret the input UUID, the return value will not be -1 (failure) or 4 (random UUID).

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [x] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
