### PR TITLE
Fix issue in mappings.instantiate_all()

### DIFF
--- a/bindings/python/dlite-collection-python.i
+++ b/bindings/python/dlite-collection-python.i
@@ -301,6 +301,7 @@ class Collection(Instance):
                     **kwargs
                 ):
                     yield inst
+
         elif property_mappings:
             raise _dlite.DLiteError(
                 '`metaid` is required when `property_mappings` is true')

--- a/bindings/python/mappings.py
+++ b/bindings/python/mappings.py
@@ -113,7 +113,7 @@ def instance_routes(
 def instantiate_from_routes(
     meta: str | dlite.Metadata | Namespace,
     routes: dict[str, MappingStep],
-    routedict: dict[str, int] = None,
+    routedict: "Optional[dict[str, int]]" = None,
     id: "Optional[str]" = None,
     default: "Optional[dlite.Instance]" = None,
     quantity: "Type[Quantity]" = Quantity,
@@ -146,7 +146,8 @@ def instantiate_from_routes(
     if default and default.meta.uri != meta.uri:
         raise f"`default` must be an instance of {meta.uri}"
 
-    routedict = routedict or {}
+    if routedict is None:
+        routedict = {}
 
     values = {}
     for prop in meta["properties"]:
@@ -170,14 +171,8 @@ def instantiate_from_routes(
     dimensions = infer_dimensions(meta, values)
     inst = meta(dimensions=dimensions, id=id)
 
-    for key, value in routes.items():
-        try:
-            val = value.eval(magnitude=True, unit=meta.getprop(key).unit)
-        except MissingRelationError:
-            if not default:
-                raise
-            val = default[key]
-        inst[key] = val
+    for key, value in values.items():
+        inst[key] = value
 
     return inst
 

--- a/bindings/python/mappings.py
+++ b/bindings/python/mappings.py
@@ -283,6 +283,9 @@ def instantiate_all(
     elif isinstance(meta, Namespace):
         meta = dlite.get_instance(str(meta).rstrip("/#"))
 
+    if default:
+        allow_incomplete = True
+
     routes = instance_routes(
         meta=meta,
         instances=instances,
@@ -305,11 +308,17 @@ def instantiate_all(
             if routedict and name in routedict:
                 outer[name] = routedict[name]
                 yield outer
-            else:
+            elif name in routes:
                 step = routes[name]
-                for inner in range(step.number_of_routes()):
-                    outer[name] = inner
+                nroutes = step.number_of_routes()
+                if nroutes:
+                    for inner in range(nroutes):
+                        outer[name] = inner
+                        yield outer
+                elif allow_incomplete:
                     yield outer
+            elif allow_incomplete:
+                yield outer
 
     for route_dict in routedicts(len(property_names) - 1):
         yield instantiate_from_routes(

--- a/examples/read-csv/main.py
+++ b/examples/read-csv/main.py
@@ -1,5 +1,6 @@
 try:
     import pandas  # noqa: F401
+    import pytables  # noqa: F401
 except ImportError:
     import sys
     sys.exit(44)  # skip this test if pandas is not available


### PR DESCRIPTION
# Description
Do not raise InsufficientMappingError if a target property is mapped to a concept with not input mappings to when `allow_incomplete=True` or `default` is given.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
