### PR TITLE
Reverted use of actions/upload-artifact@v4 to v3

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -182,7 +182,7 @@ jobs:
         CIBW_MUSLLINUX_I686_IMAGE: ${{ env.CONTAINER_REGISTRY }}/sintef/dlite-python-musllinux_1_1_i686:latest
 
     - name: Store wheels for publishing
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: wheelhouse/*.whl
@@ -224,7 +224,7 @@ jobs:
       run: python -m build --no-isolation --sdist python
 
     - name: Store sdist for publishing
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: sdist
         path: python/dist/*
@@ -236,7 +236,7 @@ jobs:
 
     steps:
     - name: Retrieve wheels and sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         path: dist
 


### PR DESCRIPTION
# Description
Reverted use of actions/upload-artifact@v4 to v3

This is just a temporary solution since v3 will be deprecated Nov. 30, 2024.


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
