### PR TITLE
Infer default values for the `uuid` and `single` options of asdict()

### DIFF
--- a/.github/docker/Dockerfile-manylinux.template
+++ b/.github/docker/Dockerfile-manylinux.template
@@ -75,7 +75,8 @@ RUN mkdir -p /ci/pip_cache && \
     python3.${minor} -m pip install -U pip && \
     python3.${minor} -m pip install -U setuptools wheel && \
     python3.${minor} -m pip install -U --cache-dir /ci/pip_cache cmake oldest-supported-numpy && \
-    python3.${minor} -m pip install --cache-dir /ci/pip_cache --prefer-binary -r /tmp/requirements_full.txt -r /tmp/requirements_dev.txt; \
+    python3.${minor} -m pip install --cache-dir /ci/pip_cache --prefer-binary -r /tmp/requirements_full.txt -r /tmp/requirements_dev.txt && \
+    python3.${minor} -m pip list ; \
   done
 
 {{ EXTRA_POST }}

--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -692,12 +692,13 @@ def get_instance(
             iterfun(self),
         )
 
-    def asdict(self, soft7=True, uuid=True, single=True):
+    def asdict(self, soft7=True, uuid=None, single=None):
         """Returns a dict representation of self.
 
         Arguments:
             soft7: Whether to structure metadata as SOFT7.
-            uuid: Whether to include UUID in the dict.
+            uuid: Whether to include UUID in the dict.  The default is true
+                if `single=True` and URI is None, otherwise it is false.
             single: Whether to return in single-entity format.
                 If None, single-entity format is used for metadata and
                 multi-entity format for data instances.
@@ -705,6 +706,9 @@ def get_instance(
         dct = d = {}
         if single is None:
             single = self.is_meta
+
+        if uuid is None:
+            uuid = single and self.uri
 
         if not single:
             d = {}

--- a/bindings/python/tests/test_utils.py
+++ b/bindings/python/tests/test_utils.py
@@ -178,7 +178,9 @@ item1 = Item([2], properties={"name": "a", "f": [3.14, 2.72]})
 item2 = Item([3], properties={
     "name": "b", "f": [float("-inf"), 0, float("inf")]
 })
-dims = infer_dimensions(meta=Item, values=item1.asdict()["properties"])
+dims = infer_dimensions(
+    meta=Item, values=item1.asdict(single=True)["properties"]
+)
 assert dims == {"nf": 2}
 
 Ref = dlite.get_instance("http://onto-ns.com/meta/0.1/Ref")
@@ -186,5 +188,5 @@ ref = Ref(dimensions={"nitems": 2, "nrefs": 1})
 ref.item = item1
 ref.items = item1, item2
 ref.refs = [ref]
-dims = infer_dimensions(meta=Ref, values=ref.asdict()["properties"])
+dims = infer_dimensions(meta=Ref, values=ref.asdict(single=True)["properties"])
 assert dims == {"nitems": 2, "nrefs": 1}

--- a/storages/python/python-storage-plugins/bson.py
+++ b/storages/python/python-storage-plugins/bson.py
@@ -104,7 +104,7 @@ class bson(dlite.DLiteStorageBase):
 
         """
         self._data[inst.uuid] = inst.asdict(
-            soft7=dlite.asbool(self.options.soft7)
+            soft7=dlite.asbool(self.options.soft7), uuid=True, single=True
         )
 
     def queue(

--- a/storages/python/python-storage-plugins/mongodb.py
+++ b/storages/python/python-storage-plugins/mongodb.py
@@ -72,7 +72,7 @@ class mongodb(dlite.DLiteStorageBase):
 
     def save(self, inst):
         """Stores `inst` in current storage."""
-        document = inst.asdict(uuid=True)
+        document = inst.asdict(uuid=True, single=True)
         self.collection.insert_one(document)
 
     def queue(self, pattern=None):

--- a/storages/python/python-storage-plugins/yaml.py
+++ b/storages/python/python-storage-plugins/yaml.py
@@ -160,7 +160,7 @@ class yaml(dlite.DLiteStorageBase):
             The bytes (or bytearray) object that the instance is saved to.
         """
         return pyyaml.safe_dump(
-            inst.asdict(soft7=soft7, uuid=with_uuid),
+            inst.asdict(soft7=soft7, uuid=with_uuid, single=True),
             default_flow_style=False,
             sort_keys=False,
         ).encode()


### PR DESCRIPTION
# Description
See comments in issue #811

Infer default values for the `uuid` and `single` options of asdict() to None.

**Note**: This PR changes the behaviour of DLite and may break existing code. 

All tests that are affected by this change have been updated.

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
