### PR TITLE
Added openssl to the musllinux wheel

### DIFF
--- a/.github/docker/Dockerfile-musllinux.template
+++ b/.github/docker/Dockerfile-musllinux.template
@@ -38,6 +38,7 @@ RUN apk add -u \
   rasqal \
   hdf5 \
   swig \
+  openssl \
   rust \
   cargo && \
   # Unpack static libraries


### PR DESCRIPTION
# Description
This CI run seems to fail because of missing OpenSSL library: https://github.com/SINTEF/dlite/actions/runs/9451688079/job/26033221914?pr=833

Try to install openssl with apk when building docker image for musllinux.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [x] Is the change limited to one issue?
- [x] Does this PR close the issue?
- [x] Is the code easy to read and understand?
- [x] Do all new feature have an accompanying new test?
- [x] Has the documentation been updated as necessary?
