### PR TITLE
Do not set cmake option `Python3_FIND_VIRTUALENV=ONLY` when building for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,8 +246,10 @@ if(WITH_PYTHON)
     message(STATUS "Detected virtual environment $ENV{VIRTUAL_ENV}")
 
     if(NOT Python3_FIND_VIRTUALENV)
-      message(STATUS "Setting Python3_FIND_VIRTUALENV=ONLY")
-      set(Python3_FIND_VIRTUALENV=ONLY)
+      if(NOT WIN32)
+        message(STATUS "Setting Python3_FIND_VIRTUALENV=ONLY")
+        set(Python3_FIND_VIRTUALENV=ONLY)
+      endif()
     endif()
 
     if(NOT PYTHON_VERSION)


### PR DESCRIPTION
# Description
The following CI fails when looking for Python with the cmake option `Python3_FIND_VIRTUALENV=ONLY`: https://github.com/SINTEF/dlite/actions/runs/9452204302/job/26035729291

Try to not set this option when building for Windows.


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
