### PR TITLE
Explicitly set python 3.10 in ci_tests and cd_docs in gitub workflows.

### DIFF
--- a/.github/workflows/cd_docs.yml
+++ b/.github/workflows/cd_docs.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -4,11 +4,17 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
 
       # We do not install rdflib0-dev here, since we want to test
       # DLite both with and without rdflib (Redland) support and the

--- a/python/setup.py
+++ b/python/setup.py
@@ -195,7 +195,7 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires="numpy",
+    install_requires="numpy>=1.14.5,<1.27.0",
     #install_requires=requirements,
     #extras_require=extra_requirements,
     packages=["dlite"],


### PR DESCRIPTION
# Description
Also changed ubuntu to ubuntu-latest in ci-tests

In the ci_tests workflow, all dependencies are installed (also those of docs). 
The docs dependencies are for a specific version and are not a range of versions,
hence they fail if the required version does not support older python-versions. 

Python3.10 set as standard for this reason.

# Description


## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
