### PR TITLE
using plugin in path that is set after instantiation of a data mode fails.

### DIFF
--- a/examples/storage_plugin/main.py
+++ b/examples/storage_plugin/main.py
@@ -10,6 +10,7 @@ thisdir = Path(__file__).resolve().parent
 dlite.storage_path.append(thisdir / "entities" / "TempProfile.json")
 DataModel = dlite.get_instance("http://onto-ns.com/meta/0.1/TempProfile")
 dlite.python_storage_plugin_path.append(thisdir  / "plugins")
+#DataModel = dlite.get_instance("http://onto-ns.com/meta/0.1/TempProfile")
 
 # Create instance from dataset
 inst = dlite.Instance.from_location("tempprofile", thisdir / "dataset.txt",

--- a/examples/storage_plugin/main.py
+++ b/examples/storage_plugin/main.py
@@ -5,6 +5,10 @@ import dlite
 
 # Set search path to our user-defined storage plugin
 thisdir = Path(__file__).resolve().parent
+#dlite.python_storage_plugin_path.append(thisdir  / "plugins")
+
+dlite.storage_path.append(thisdir / "entities" / "TempProfile.json")
+DataModel = dlite.get_instance("http://onto-ns.com/meta/0.1/TempProfile")
 dlite.python_storage_plugin_path.append(thisdir  / "plugins")
 
 # Create instance from dataset

--- a/python/setup.py
+++ b/python/setup.py
@@ -195,7 +195,7 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires="numpy",
+    install_requires="numpy>=1.14.5,<2.0.0",
     #install_requires=requirements,
     #extras_require=extra_requirements,
     packages=["dlite"],

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -31,7 +31,7 @@ struct _DLiteStoragePluginIter {
 /* Global variables for dlite-storage-plugins */
 typedef struct {
   PluginInfo *storage_plugin_info;  /* reference to storage plugin info */
-  unsigned char storage_plugin_path_hash[32];  /* Sha256 hash of plugin paths */
+  unsigned char storage_plugin_path_hash[32];  /* Sha3 hash of plugin paths */
 } Globals;
 
 
@@ -119,7 +119,7 @@ const DLiteStoragePlugin *dlite_storage_plugin_get(const char *name)
 
   /* ...otherwise, if any plugin path has changed, reload all plugins
      and try again */
-  if (pathshash(hash, sizeof(hash), &info->paths) == 0) {
+  if (pathshash(hash, sizeof(hash), &info->paths, DSL_EXT) == 0) {
 
     if (memcmp(g->storage_plugin_path_hash, hash, sizeof(hash)) != 0) {
       plugin_load_all(info);

--- a/src/pathshash.c
+++ b/src/pathshash.c
@@ -6,24 +6,30 @@
 #include "pathshash.h"
 
 /*
-  Calculate sha3 hash of `paths` and stores it in `hash`.
+  Calculate sha3 hash of all files in `paths` and stores it in `hash`.
   `hashsize` is the size of `hash` in bytes. Should be 32, 48 or 64.
+
+  If `pattern` is given, it should be a glob pattern for selecting what
+  files to include.
+
   Returns non-zero on error.
 */
-int pathshash(unsigned char *hash, int hashsize, const FUPaths *paths)
+int pathshash(unsigned char *hash, int hashsize, const FUPaths *paths,
+              const char *pattern)
 {
   sha3_context c;
   FUIter *iter;
   unsigned bitsize = hashsize * 8;
   const unsigned char *buf;
   const char *path;
-  if (!(iter = fu_pathsiter_init(paths, NULL))) return 1;
+  if (!(iter = fu_startmatch(pattern, paths)))
+    return err(1, "cannot initiate paths iterator (%d)", (paths) ? (int)paths->n : -1);
   if (sha3_Init(&c, bitsize))
     return err(1, "invalid hash size: %d bytes", hashsize);
-  while ((path = fu_pathsiter_next(iter)))
+  while ((path = fu_nextmatch(iter)))
     sha3_Update(&c, path, strlen(path));
   buf = sha3_Finalize(&c);
-  fu_pathsiter_deinit(iter);
+  fu_endmatch(iter);
   memcpy(hash, buf, hashsize);
   return 0;
 }

--- a/src/pathshash.h
+++ b/src/pathshash.h
@@ -4,11 +4,16 @@
 #include "utils/fileutils.h"
 
 /**
-  Calculate sha3 hash of `paths` and stores it in `hash`.
+  Calculate sha3 hash of all files in `paths` and stores it in `hash`.
   `hashsize` is the size of `hash` in bytes. Should be 32, 48 or 64.
+
+  If `pattern` is given, it should be a glob pattern for selecting what
+  files to include.
+
   Returns non-zero on error.
 */
-int pathshash(unsigned char *hash, int hashsize, const FUPaths *paths);
+int pathshash(unsigned char *hash, int hashsize, const FUPaths *paths,
+              const char *pattern);
 
 
 #endif  /* _PATHSHASH_H */


### PR DESCRIPTION
# Description
Ensure that Python storages are reloaded if the Python storage plugin path has changed.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
