### PR TITLE
Fixed memory leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,8 @@ if(MEMORYCHECK_COMMAND)
     add_custom_command(
       OUTPUT ${logfile}
       COMMAND ${CMAKE_COMMAND}
-        -E env PYTHONMALLOC=malloc ${MEMORYCHECK_COMMAND}
+        -E env PYTHONMALLOC=malloc DLITE_ATEXIT_FREE=
+        -- ${MEMORYCHECK_COMMAND}
         --leak-check=yes
         --show-leak-kinds=all
         --keep-debuginfo=yes

--- a/cmake/valgrind-dlite.supp
+++ b/cmake/valgrind-dlite.supp
@@ -220,14 +220,3 @@
    fun:expand_dynamic_string_token
    fun:_dl_map_object
 }
-
-# For Pydantic
-
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:realloc
-   ...
-   fun:PyInit__pydantic_core
-}

--- a/cmake/valgrind-dlite.supp
+++ b/cmake/valgrind-dlite.supp
@@ -220,3 +220,14 @@
    fun:expand_dynamic_string_token
    fun:_dl_map_object
 }
+
+# For Pydantic
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   fun:PyInit__pydantic_core
+}

--- a/cmake/valgrind-python.supp
+++ b/cmake/valgrind-python.supp
@@ -634,7 +634,6 @@
    fun:Py_BytesMain
 }
 
-
 {
    Leak in numpy random_bit_generator (py311, alvis)
    Memcheck:Leak
@@ -647,6 +646,15 @@
    fun:call_init
    fun:_dl_init
    fun:_dl_catch_exception
+}
+
+{
+   Leak in pydantic initialisation (py311)
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   ...
+   fun:PyInit__pydantic_core
 }
 
 

--- a/cmake/valgrind-python.supp
+++ b/cmake/valgrind-python.supp
@@ -635,6 +635,21 @@
 }
 
 
+{
+   Leak in numpy random_bit_generator (py311, alvis)
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   obj:/usr/lib64/libgomp.so.1.0.0
+   obj:/usr/lib64/libgomp.so.1.0.0
+   obj:/usr/lib64/libgomp.so.1.0.0
+   fun:call_init
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+}
+
+
 # ------------------------------------
 # Python plugins
 # ------------------------------------

--- a/src/dlite-mapping.c
+++ b/src/dlite-mapping.c
@@ -100,9 +100,20 @@ DLiteMapping *mapping_create_rec(const char *output_uri, Instances *inputs,
     }
     if (ignore) continue;
 
+    /*
+      FIXME: avoid memory leak
+      Implement dlite_mapping_plugin_free() and call it here.
+
+      Even better, implement caching in dlite_mapping_plugin_next()
+      such that it returns borrowed references to the api. Add a function
+      to clear the cache.
+    */
     if (!cheapest || cost < lowest_cost) {
+      //dlite_mapping_plugin_free(cheapest);
       cheapest = api;
       lowest_cost = cost;
+    } else {
+      //dlite_mapping_plugin_free(api);
     }
   }
   if (!(api = cheapest)) goto fail;

--- a/src/dlite-misc.c
+++ b/src/dlite-misc.c
@@ -465,6 +465,7 @@ int dlite_add_dll_path(void)
 /* Local state for this module. */
 typedef struct {
   int in_atexit;
+  int finalizing;
 } Locals;
 
 
@@ -496,7 +497,8 @@ static Locals *get_locals(void)
 static void _handle_atexit(void) {
 
   /* No extra finalisation is needed if we already are in an atexit handler */
-  if (dlite_globals_in_atexit()) return;
+  //if (dlite_globals_in_atexit()) return;
+  if (dlite_globals_in_atexit() && !getenv("DLITE_ATEXIT_FREE")) return;
 
   /* Mark that we are in an atexit handler */
   dlite_globals_set_atexit();
@@ -582,6 +584,11 @@ void dlite_init(void)
 void dlite_finalize(void)
 {
   Session *s = session_get_default();
+  Locals *locals = get_locals();
+
+  /* Ensure that we only finalize once. */
+  if (locals->finalizing) return;
+  locals->finalizing = 1;
 
   /* Don't free anything if we are in an atexit handler */
   if (dlite_globals_in_atexit() && !getenv("DLITE_ATEXIT_FREE")) return;

--- a/src/pyembed/dlite-python-storage.c
+++ b/src/pyembed/dlite-python-storage.c
@@ -46,7 +46,7 @@ static void free_globals(void *globals)
   if (g->initialised) fu_paths_deinit(&g->paths);
 
   /* Do not call Py_DECREF if we are in an atexit handler */
-  if (!dlite_globals_in_atexit() || getenv("DLITE_ATEXIT_FREE")) {
+  if (!dlite_globals_in_atexit()) {
     Py_XDECREF(g->loaded_storages);
     g->loaded_storages = NULL;
   }

--- a/storages/json/dlite-json-storage.c
+++ b/storages/json/dlite-json-storage.c
@@ -318,9 +318,12 @@ DLiteInstance *json_memload(const DLiteStoragePlugin *api,
                             const unsigned char *buf, size_t size,
                             const char *id, const char *options)
 {
+  DLiteInstance *inst;
   DLiteStorage *s = json_loader(api, NULL, buf, size, options);
-  DLiteInstance *inst = json_load(s, id);
+  if (!s) return NULL;
+  inst = json_load(s, id);
   json_close(s);
+  free(s);
   return inst;
 }
 


### PR DESCRIPTION
# Description
Fixed memory leaks. The following was done:
- Fixed leak in json_memload()
- Fixed leak in global session when running with DLITE_ATEXIT_FREE set (instead of accepting it, as suggested in PR #888)
- Added a FIXME for a leak in mapping_create_rec() in src/dlite-mappings.c. More work is required. Described in issue #894 
- Ignore external leaks in pydantic and numpy random_bit_generator
- Set DLITE_ATEXIT_FREE when running `make memcheck`. 

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
