### PR TITLE
Updated cppcheck and corrected some errors that it found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if(WITH_HDF5)
   endif()
 endif()
 
+
 #
 # Redland
 # =======
@@ -436,19 +437,31 @@ endif()
 
 find_program(CPPCHECK cppcheck)
 if(CPPCHECK)
+
+  # Create cppcheck-build-dir
+  file(MAKE_DIRECTORY ${dlite_BINARY_DIR}/cppcheck)
+
+  # Ignore all directories matching "build-*"
+  file(GLOB builddirs build-*)
+  foreach(dir ${builddirs})
+    set(cppcheck_ignore_options "${cppcheck_ignore_options} -i ${dir}")
+  endforeach()
+
   add_test(
     NAME static-code-analysis
     COMMAND ${CPPCHECK}
       --language=c -q --force --error-exitcode=2 --inline-suppr
-      -i build -i python
-      -I${dlite_SOURCE_DIR}/src ${NUMBER_OF_CPUS_OPTION}
+      --cppcheck-build-dir=${dlite_BINARY_DIR}/cppcheck
+      -i build -i python ${cppcheck_ignore_options}
+      -I${dlite_SOURCE_DIR}/src -I${dlite_BINARY_DIR}/src
+      ${NUMBER_OF_CPUS_OPTION}
       ${dlite_SOURCE_DIR}/src
       ${dlite_SOURCE_DIR}/storages
       ${dlite_SOURCE_DIR}/tools
       ${dlite_SOURCE_DIR}/bindings
       ${dlite_SOURCE_DIR}/examples
       ${dlite_BINARY_DIR}/src
-      ${dlite_BINARY_DIR}/storates
+      ${dlite_BINARY_DIR}/storages
       ${dlite_BINARY_DIR}/tools
       ${dlite_BINARY_DIR}/bindings
       #${dlite_BINARY_DIR}/examples

--- a/doc/user_guide/transactions.md
+++ b/doc/user_guide/transactions.md
@@ -1,6 +1,6 @@
 Transactions
 ============
-Transaction is a concept that comes from SOFT, which allows to easy manage arbitrary long series of immutable (frozen) instances, while ensuring provenance.
+The Transaction concept comes from SOFT. It allows to easily manage arbitrary long series of immutable (frozen) instances, while ensuring provenance.
 Conceptually, it shares many similarities with [git](https://git-scm.com).
 
 A basic usage for transactions is to take snapshots of the current state of your system.

--- a/doc/user_guide/transactions.md
+++ b/doc/user_guide/transactions.md
@@ -1,6 +1,6 @@
 Transactions
 ============
-Transactions is a concept that comes from SOFT, which allows to easy manage arbitrary long series of immutable (frozen) instances, while ensuring provenance.
+Transaction is a concept that comes from SOFT, which allows to easy manage arbitrary long series of immutable (frozen) instances, while ensuring provenance.
 Conceptually, it shares many similarities with [git](https://git-scm.com).
 
 A basic usage for transactions is to take snapshots of the current state of your system.

--- a/src/dlite-datamodel.c
+++ b/src/dlite-datamodel.c
@@ -26,7 +26,7 @@ DLiteDataModel *dlite_datamodel(const DLiteStorage *s, const char *id)
   DLiteDataModel *d=NULL;
   char **uuids=NULL;
   char uuid[DLITE_UUID_LENGTH+1];
-  int uuidver=4;
+  int uuidver;
 
   /* allow id to be NULL if the storage only contains one instance */
   if (!id || !*id) {
@@ -43,12 +43,13 @@ DLiteDataModel *dlite_datamodel(const DLiteStorage *s, const char *id)
     }
   }
 
+  if ((uuidver = dlite_get_uuid(uuid, id)) < 0)
+    FAIL1("failed generating UUID from id \"%s\"", id);
+
   if (s->idflag == dliteIDKeepID) {
       d = s->api->dataModel(s, id);
   } else if (!id || !*id || s->idflag == dliteIDTranslateToUUID ||
       s->idflag == dliteIDRequireUUID) {
-    if ((uuidver = dlite_get_uuid(uuid, id)) < 0)
-      FAIL1("failed generating UUID from id \"%s\"", id);
     if (uuidver != 0 && s->idflag == dliteIDRequireUUID)
       FAIL1("id is not a valid UUID: \"%s\"", id);
     d = s->api->dataModel(s, uuid);
@@ -217,7 +218,7 @@ int dlite_copy_to_flat(void *dst, const void *src, size_t size,
   char *q=dst;
   void **p=(void **)src;
 
-  if (!(ind = calloc(ndims, sizeof(int)))) 
+  if (!(ind = calloc(ndims, sizeof(int))))
     FAILCODE(dliteMemoryError, "allocation failure");
 
   for (i=0; i<(int)ndims-1; i++) p = p[ind[i]];

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -3645,18 +3645,24 @@ int dlite_metamodel_set_string(DLiteMetaModel *model, const char *name,
 {
   size_t i;
   char *p;
-  if (!(p = strdup(s))) return err(dliteMemoryError, "allocation failure");
-  if (dlite_metamodel_set_value(model, name, NULL)) return 1;
+  if (!(p = strdup(s)))
+    FAILCODE(dliteMemoryError, "allocation failure");
+  if (dlite_metamodel_set_value(model, name, NULL))
+    goto fail;
   for (i=0; i < model->nvalues; i++)
     if (strcmp(name, model->values[i].name) == 0) {
       Value *v = model->values + i;
       assert(v->data == NULL);
-      if (!(v->strp = malloc(sizeof(char **)))) return 1;
+      if (!(v->strp = malloc(sizeof(char **))))
+        FAILCODE(dliteMemoryError, "allocation failure");
       *(v->strp) = p;
       v->data = v->strp;
       return 0;
     }
   abort();  /* should never be reached */
+ fail:
+  if (p) free(p);
+  return 1;
 }
 
 

--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -1275,11 +1275,12 @@ int dlite_jstore_remove(JStore *js, const char *id)
  */
 DLiteJStoreIter *dlite_jstore_iter_create(JStore *js, const char *metaid)
 {
-  DLiteJStoreIter *iter;
+  DLiteJStoreIter *iter=NULL;
   if (!(iter = calloc(1, sizeof(DLiteJStoreIter))))
-    return err(dliteMemoryError, "allocation failure"), NULL;
-  if (jstore_iter_init(js, &iter->jiter)) return NULL;
-  if (metaid && dlite_get_uuid(iter->metauuid, metaid) < 0) return NULL;
+    FAILCODE(dliteMemoryError, "allocation failure");
+  if (jstore_iter_init(js, &iter->jiter)) goto fail;
+  if (metaid && dlite_get_uuid(iter->metauuid, metaid) < 0) goto fail;
+ fail:
   return iter;
 }
 

--- a/src/dlite-mapping-plugins.c
+++ b/src/dlite-mapping-plugins.c
@@ -141,7 +141,7 @@ const DLiteMappingPlugin *dlite_mapping_plugin_get(const char *name)
   if ((api = dlite_python_mapping_get_api(name))) return api;
 #endif
   /* Cannot find API */
-  int i, j=2, m=0;
+  int i=0, j=2, m=0;
   char *buf=NULL;
   size_t size=0;
   const char **paths;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -121,9 +121,15 @@ if(WITH_THREADS)
   if(Threads_FOUND)
     set(HAVE_THREADS TRUE)
     add_definitions(-DHAVE_THREADS)
+
+    # On some 32-bit systems (like manylinux2014_i686) we have to
+    # explicitly link with the threads library
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+      list(APPEND extra_link_libraries ${CMAKE_THREAD_LIBS_INIT})
+    endif()
+
   endif()
 endif()
-
 
 # -- additional checks...
 include(CheckCSourceCompiles)

--- a/src/utils/compat.h
+++ b/src/utils/compat.h
@@ -31,6 +31,7 @@
 #ifdef HAVE_STDLIB_H
 # include <stdlib.h>
 #elif !defined HAVE_SIZE_T
+// cppcheck-suppress preprocessorErrorDirective
 #error "system is missing definition of size_t"
 #endif
 

--- a/src/utils/tests/test_dsl.c
+++ b/src/utils/tests/test_dsl.c
@@ -20,6 +20,7 @@ typedef int (*Sum)(int x, int y);
 
 MU_TEST(test_dsl_open)
 {
+  // cppcheck-suppress unknownMacro
   char *path = STRINGIFY(BINDIR) "/" DSL_PREFIX "test_dsl_lib" DSL_EXT;
   const char *msg;
   printf("\n*** path='%s'\n", path);

--- a/src/utils/tests/test_fileutils.c
+++ b/src/utils/tests/test_fileutils.c
@@ -80,7 +80,7 @@ MU_TEST(test_fu_dirname)
   mu_assert_string_eq("a/bb", s);
   free(s);
 
-  s = fu_dirname("a" DIRSEP "bb" DIRSEP "ccc.txt");
+  s = fu_dirname("a" DIRSEP "bb" DIRSEP "ccc.txt");  // cppcheck-suppress unknownMacro
   mu_assert_string_eq("a" DIRSEP "bb", s);
   free(s);
 


### PR DESCRIPTION
# Description
Updated cppcheck and corrected some errors that it found.

Background for this PR: After updating cppcheck to 2.13.0, it pointed out a few memory leaks. To make it easier to utilise cppcheck, this PR runs it with cache enabled. After the initial run, this makes cppcheck very fast, making it convenient to use during development.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
