### PR TITLE
Do not print C errors by default

### DIFF
--- a/bindings/python/dlite-entity-python.i
+++ b/bindings/python/dlite-entity-python.i
@@ -333,10 +333,12 @@ def get_instance(
     # Override default generated __init__() method
     def __init__(self, *args, **kwargs):
 
-        # The swig-generated __new__() method is not a standard wrapper
-        # function and therefore bypass the standard error checking.
-        # Check manually that we are not in an error state.
-        _dlite.errcheck()
+        # Some versions of SWIG may generate a __new__() method that
+        # is not a standard wrapper function and will therefore bypass
+        # the standard error checking.  Check manually that we are not
+        # in an error state.
+        if hasattr(self, "__new__"):
+            _dlite.errcheck()
 
         if self is None:
             raise _dlite.DLitePythonError(f"cannot create dlite.Instance")

--- a/doc/user_guide/environment_variables.md
+++ b/doc/user_guide/environment_variables.md
@@ -41,9 +41,13 @@ DLite-specific environment variables
     plugin search paths, while it only affects the plugin search paths on
     Linux.
 
-  - **DLITE_PYDEBUG**: Traceback from errors happening Python plugins are normally
-    lost.  But, if `DLITE_PYDEBUG` is defined, a Python error message will be
-    written to standard error.
+  - **DLITE_PYDEBUG**: If defined, it will turn on printing error
+    messages from C to standard error.
+
+    It will also enable tracebacks from exceptions happening in Python
+    plugins.  Traceback from exceptions happening in Python plugins
+    are normally lost.  But, with `DLITE_PYDEBUG` defined, the full error
+    message, including traceback, will be written to standard error.
 
   - **DLITE_ATEXIT_FREE**: Free memory at exit.  This might be useful to avoid
     getting false positive when tracking down memory leaks with tools like valgrind.

--- a/doc/user_guide/environment_variables.md
+++ b/doc/user_guide/environment_variables.md
@@ -44,9 +44,9 @@ DLite-specific environment variables
   - **DLITE_PYDEBUG**: If defined, it will turn on printing error
     messages from C to standard error.
 
-    It will also enable tracebacks from exceptions happening in Python
-    plugins.  Traceback from exceptions happening in Python plugins
-    are normally lost.  But, with `DLITE_PYDEBUG` defined, the full error
+    It will also enable traceback from exceptions occuring in Python
+    plugins.  Traceback from exceptions occurring in Python plugins
+    are normally lost.  With `DLITE_PYDEBUG` defined the full error
     message, including traceback, will be written to standard error.
 
   - **DLITE_ATEXIT_FREE**: Free memory at exit.  This might be useful to avoid

--- a/src/dlite-misc.c
+++ b/src/dlite-misc.c
@@ -542,7 +542,7 @@ void dlite_globals_set(DLiteGlobals *globals_handler)
 /* Error handler for DLite. */
 static void dlite_err_handler(const ErrRecord *record)
 {
-  if (!dlite_err_ignored_get(record->eval))
+  if (!dlite_err_ignored_get(record->eval) && getenv("DLITE_PYDEBUG"))
     err_default_handler(record);
 }
 


### PR DESCRIPTION
# Description
Do not print C errors by default.

Also, avoid calling _dlite.errcheck() as the first thing in Instance.__init__() if SWIG doesn't generate a __new__() method.


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
