### PR TITLE
Fixed logical error. Do not print errors from C to stderr unless DLITE_PYDEBUG is defined

### DIFF
--- a/src/dlite-misc.c
+++ b/src/dlite-misc.c
@@ -549,7 +549,7 @@ static void dlite_err_handler(const ErrRecord *record)
 {
 #ifdef WITH_PYTHON
   if (record->level != errLevelError ||
-      !getenv("DLITE_PYDEBUG") ||
+      getenv("DLITE_PYDEBUG") ||
       !dlite_err_ignored_get(record->eval))
     err_default_handler(record);
 #else  /* WITH_PYTHON */


### PR DESCRIPTION
…
# Description
Fixed logical error/typo. Do not print errors from C to stderr unless DLITE_PYDEBUG is defined.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
