### PR TITLE
Address dlite-validate output confusing information

### DIFF
--- a/bindings/python/scripts/dlite-validate
+++ b/bindings/python/scripts/dlite-validate
@@ -5,7 +5,22 @@ import sys
 import argparse
 import json
 import re
+import ctypes
+from ctypes.util import find_library
 from pathlib import Path
+
+# Silence warning about behavior by setting environment variable
+# DLITE_BEHAVIOR=OFF before importing dlite.
+# This must be done at c-level outside os.environ.
+clib = find_library("c")
+dll = ctypes.CDLL(clib)
+setenv = dll.setenv
+setenv.argtypes = [
+    ctypes.POINTER(ctypes.c_char),  # name
+    ctypes.POINTER(ctypes.c_char),  # value
+    ctypes.c_int,                   # overwrite
+]
+setenv(b"DLITE_BEHAVIOR", b"OFF", 1)
 
 import dlite
 

--- a/src/dlite-behavior.c
+++ b/src/dlite-behavior.c
@@ -128,7 +128,7 @@ int dlite_behavior_get(const char *name)
     const char *ver = dlite_get_version();  // current version
     b->value = (strcmp_semver(ver, b->version_new) >= 0) ? 1 : 0;
 
-    dlite_warnx("Behavior `%s` is not configured. "
+    dlite_warnx("Behavior change `%s` is not configured. "
                 "It will be enabled by default from v%s. "
                 "See https://sintef.github.io/dlite/user_guide/configure_behavior_changes.html for more info.",
                 b->name, b->version_new);


### PR DESCRIPTION
# Description
If I understood issue #978 correctly, we should not show the warning about the behavior change from `dlite-validate`. I agree on that.

But how is this solved best? The current implementation expects the user to set environment variable `DLITE_BEHAVIOR=OFF` to turn off all warnings about behavior changes. If we are happy with that, we are done.

If we want tools like `dlite-validate` to never show warnings about behavior changes, we need more. Possible approaches:
- Set `DLITE_BEHAVIOR=OFF` within the tool before importing `dlite`. This is currently implemented in this PR. It is quite a hack and not a very attractive solution...
- If `dlite` is imported from Python, it could look for global variables starting with "DLITE_" and set corresponding environment variables internally. I like this better, since it would be a quite general and nice way to configure `dlite` from Python applications. Now implemented in PR #989 

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
