### PR TITLE
Fix segfault if dimensions is null

### DIFF
--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -728,6 +728,8 @@ static DLiteInstance *parse_instance(const char *src, jsmntok_t *obj,
           } else
             FAIL1("missing key \"%s\" in JSON object", p->name);
         } else {
+          if (!ptr)
+            FAIL1("cannot assign property with NULL destination: %s", p->name);
           if (dlite_type_scan(src+t->start, t->end - t->start, ptr, p->type,
                               p->size, 0) < 0)
             goto fail;


### PR DESCRIPTION
# Description
Avoid that dlite segfaults if "dimensions" is null (empty) in JSON and YAML input.


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
