### PR TITLE
Include the Dockerfile we build in the sha hash for checking whether a new image should be published

### DIFF
--- a/.github/workflows/container_builds_weekly.yml
+++ b/.github/workflows/container_builds_weekly.yml
@@ -93,12 +93,24 @@ jobs:
           key: buildx-cache-${{ matrix.system }}${{ matrix.type }}-${{ matrix.arch }}-${{ github.sha }}
           restore-keys: buildx-cache-${{ matrix.system }}${{ matrix.type }}-${{ matrix.arch }}-
 
+      - name: Create docker file
+        if: env.BUILD_NEW_IMAGE == 'true'
+        run: |
+          DOCKERFILE=docker_build_wheel/Dockerfile-${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}
+          mkdir -p docker_build_wheel
+          bash .github/docker/gen_dockerfile.sh ${{ matrix.system }} ${{ matrix.type }} ${{ matrix.arch }} "${{ matrix.py_minors }}" \
+            > ${DOCKERFILE}
+
+      - name: Create file with SHA hashes
+        run: |
+          SHA_FILENAME=${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}:latest.sha.txt
+          sha256sum ${DOCKERFILE} > ${SHA_FILENAME}
+
       - name: Check 'latest' parent image SHA
         run: |
           IMAGE=quay.io/pypa/${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}:latest
-          SHA_FILENAME=${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}:latest.sha.txt
           docker pull ${IMAGE}
-          docker images --no-trunc --quiet ${IMAGE} > ${SHA_FILENAME}
+          docker images --no-trunc --quiet ${IMAGE} >> ${SHA_FILENAME}
 
           CACHE_DIR=.buildx-cache-${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}
           if [ -f "${CACHE_DIR}/${SHA_FILENAME}" ] && [ "$( cat ${SHA_FILENAME} )" == "$( cat ${CACHE_DIR}/${SHA_FILENAME} )" ]; then
@@ -106,13 +118,6 @@ jobs:
           else
             echo "BUILD_NEW_IMAGE=true" >> $GITHUB_ENV
           fi
-
-      - name: Create docker file
-        if: env.BUILD_NEW_IMAGE == 'true'
-        run: |
-          mkdir -p docker_build_wheel
-          bash .github/docker/gen_dockerfile.sh ${{ matrix.system }} ${{ matrix.type }} ${{ matrix.arch }} "${{ matrix.py_minors }}" \
-            > docker_build_wheel/Dockerfile-${{ matrix.system }}${{ matrix.type }}_${{ matrix.arch }}
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_NEW_IMAGE == 'true'


### PR DESCRIPTION
# Description
The current implementation of the `container_builds_weekly.yml` only publishes the build container if the image on `quay.io/pypa/` has changed, not if we have made any changes in the Dockerfiles that we prepare for building DLite. This means that any changes we do in the Dockerfiles will not be available for the `ci_build_wheels.yml` action.

This PR fixes this broken behaviour, by also including the hash of our local Dockerfile in the file for comparing hashes. 

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
