### PR TITLE
Update patch-activate.sh

### DIFF
--- a/cmake/patch-activate.sh
+++ b/cmake/patch-activate.sh
@@ -16,8 +16,9 @@ How to use this script:
   1. Make sure that environment variable VIRTUAL_ENV is set to the
      root directory of your virtual environments.
   2. Activate your virtual environment.
-  3. Run `patch-activate.sh`
-  4. Deactivate and reactivate your virtual environment to ensure that
+  3. Install dlite
+  4. Run `patch-activate.sh`
+  5. Deactivate and reactivate your virtual environment to ensure that
      LD_LIBRARY_PATH is properly set.
 EOF
 }
@@ -42,7 +43,8 @@ if [ -z "$VIRTUAL_ENV" ]; then
    exit 1
 fi
 
-libdirs="\$VIRTUAL_ENV/lib"
+#libdirs=$(python -c 'import pathlib, site; print(":".join([f"{p}/dlite" for p in site.getsitepackages() if pathlib.Path(f"{p}/dlite").exists()] + [str(pathlib.Path(p).parent.parent) for p in site.getsitepackages()]))')
+libdirs=$(python -c 'import pathlib, site; print(":".join(str(pathlib.Path(p).parent.parent) for p in site.getsitepackages()))')
 
 # Parse options
 while true; do


### PR DESCRIPTION
# Description
Update the `patch-activate.sh` script to include both the `lib64/` and `lib/` sub-directories on systems that installs 64-bit libraries under `lib64/`.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
