### PR TITLE
Call SWIG_Python_AppendOutput() with correct number of arguments 

### DIFF
--- a/bindings/python/dlite-python.i
+++ b/bindings/python/dlite-python.i
@@ -1354,7 +1354,11 @@ PyObject *dlite_run_file(const char *path, PyObject *globals, PyObject *locals)
     argout = Py_None;
     Py_INCREF(argout);
   }
+#if SWIG_VERSION >= 0x040100
   $result = SWIG_Python_AppendOutput($result, argout, 0);
+#else
+  $result = SWIG_Python_AppendOutput($result, argout);
+#endif
 }
 
 


### PR DESCRIPTION
# Description
Call SWIG_Python_AppendOutput() with correct number of arguments depending on SWIG version.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
