### PR TITLE
MacOS - changes to the core code to allow DLite to compile on MacOS

### DIFF
--- a/src/utils/byteorder.h.in
+++ b/src/utils/byteorder.h.in
@@ -1,3 +1,5 @@
+/* .h file GENERATED FROM byterorder.h.in */
+
 /* byteorder.h - cross-platform header for byte ordering
  *
  * Copyright (C) 2017 SINTEF Materials and Chemistry
@@ -60,10 +62,10 @@
 #cmakedefine HAVE_BSWAP_64        /* Whether function bswap_64 exists */
 #cmakedefine HAVE_BSWAP_128       /* Whether function bswap_128 exists */
 
-#cmakedefine HAVE_BYTESWAP_USHORT /* Whether function _byteswap_ushort exists */
-#cmakedefine HAVE_BYTESWAP_ULONG  /* Whether function _byteswap_ulong exists */
-#cmakedefine HAVE_BYTESWAP_UINT64 /* Whether function _byteswap_uint64 exists */
-#cmakedefine HAVE_BYTESWAP_UINT128/* Whether function _byteswap_uint128 exists*/
+#cmakedefine HAVE__BYTESWAP_USHORT /* Whether function _byteswap_ushort exists */
+#cmakedefine HAVE__BYTESWAP_ULONG  /* Whether function _byteswap_ulong exists */
+#cmakedefine HAVE__BYTESWAP_UINT64 /* Whether function _byteswap_uint64 exists */
+#cmakedefine HAVE__BYTESWAP_UINT128/* Whether function _byteswap_uint128 exists*/
 
 #cmakedefine HAVE_HTOBE16         /* Whether function htobe16 exists */
 #cmakedefine HAVE_HTOBE32         /* Whether function htobe32 exists */
@@ -74,11 +76,43 @@
 #include "integers.h"
 
 #ifdef HAVE_ENDIAN_H
-# include <endian.h>
-#endif
+  #if defined(__APPLE__) && defined(__MACH__)
+    #include <machine/endian.h>
+  #else
+    #include <endian.h>
+  #endif /* defined(__APPLE__) && defined(__MACH__) */
+#endif /* ifdef HAVE_ENDIAN_H */
 
 #ifdef HAVE_BYTESWAP_H
-# include <byteswap.h>
+  #if defined(__APPLE__) && defined(__MACH__)
+    #include <libkern/OSByteOrder.h>
+    #ifdef HAVE_BSWAP_16
+      #define bswap_16(x) OSSwapInt16(x)
+    #endif
+    #ifdef HAVE_BSWAP_32
+      #define bswap_32(x) OSSwapInt32(x)
+    #endif
+    #ifdef HAVE_BSWAP_64
+      #define bswap_64(x) OSSwapInt64(x)
+    #endif
+    #ifdef HAVE_BSWAP_128
+      #define bswap_128(x) OSSwapInt128(x)
+    #endif
+    #ifdef HAVE_HTOBE16
+      #define htobe16(x) OSSwapHostToBigInt16(x)
+    #endif
+    #ifdef HAVE_HTOBE32
+      #define htobe32(x) OSSwapHostToBigInt32(x)
+    #endif
+    #ifdef HAVE_HTOBE64
+      #define htobe64(x) OSSwapHostToBigInt64(x)
+    #endif
+    #ifdef HAVE_HTOBE128
+      #define htobe128(x) OSSwapHostToBigInt128(x)
+    #endif
+  #else
+    #include <byteswap.h>
+  #endif /* defined(__APPLE__) && defined(__MACH__) */
 #endif
 
 
@@ -161,6 +195,10 @@
 # else
 #  error "Byte order not supported: " # BYTE_ORDER
 # endif
+#elif (defined(__APPLE__) && defined(__MACH__) && defined(HAVE_HTOBE16))
+# define htole16(x) (uint16_t)(x)
+# define be16toh(x) bswap_16(x)
+# define le16toh(x) (uint16_t)(x)
 #endif
 
 #ifndef HAVE_HTOBE32
@@ -177,6 +215,10 @@
 # else
 #  error "Byte order not supported: " # BYTE_ORDER
 # endif
+#elif (defined(__APPLE__) && defined(__MACH__) && defined(HAVE_HTOBE32))
+# define htole32(x) (uint32_t)(x)
+# define be32toh(x) bswap_32(x)
+# define le32toh(x) (uint32_t)(x)
 #endif
 
 #ifndef HAVE_HTOBE64
@@ -193,6 +235,10 @@
 # else
 #  error "Byte order not supported: " # BYTE_ORDER
 # endif
+#elif (defined(__APPLE__) && defined(__MACH__) && defined(HAVE_HTOBE64))
+# define htole64(x) (uint64_t)(x)
+# define be64toh(x) bswap_64(x)
+# define le64toh(x) (uint64_t)(x)
 #endif
 
 #ifdef bswap128
@@ -210,6 +256,10 @@
 #  else
 #  error "Byte order not supported: " # BYTE_ORDER
 #  endif
+# elif (defined(__APPLE__) && defined(__MACH__) && defined(HAVE_HTOBE128))
+#  define htole128(x) (uint128_t)(x)
+#  define be128toh(x) bswap_128(x)
+#  define le128toh(x) (uint128_t)(x)
 # endif
 #endif
 

--- a/src/utils/compat-src/getopt.h
+++ b/src/utils/compat-src/getopt.h
@@ -6,8 +6,6 @@
  * Released under the MIT license
  * https://github.com/takamin/win-c/blob/master/LICENSE
  */
-#ifndef _GETOPT_H_
-#define _GETOPT_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +14,8 @@ extern "C" {
 #ifdef HAVE_GETOPT
 #include <getopt.h>
 #else
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
 
     int getopt(int argc, char* const argv[],
             const char* optstring);

--- a/src/utils/config.h.in
+++ b/src/utils/config.h.in
@@ -79,20 +79,23 @@
 #cmakedefine HAVE_MBSTOWCS_S
 #cmakedefine HAVE_WCSTOMBS_S
 
+#cmakedefine HAVE_STRLCPY
+#cmakedefine HAVE_STRLCAT
+
 #cmakedefine HAVE_GETOPT
 #cmakedefine HAVE_GETOPT_LONG
 
-// #cmakedefine HAVE_SNPRINTF
-// #cmakedefine HAVE__SNPRINTF
-// #cmakedefine HAVE_VSNPRINTF
-// #cmakedefine HAVE__VSNPRINTF
-// #cmakedefine HAVE_VASPRINTF
-// #cmakedefine HAVE__VASPRINTF
-// #cmakedefine HAVE_ASPRINTF
-// #cmakedefine HAVE__ASPRINTF
-// #cmakedefine HAVE_LOCALECONV
-// #cmakedefine HAVE_VA_COPY
-// #cmakedefine HAVE___VA_COPY
+#cmakedefine HAVE_SNPRINTF
+#cmakedefine HAVE__SNPRINTF
+#cmakedefine HAVE_VSNPRINTF
+#cmakedefine HAVE__VSNPRINTF
+#cmakedefine HAVE_VASPRINTF
+#cmakedefine HAVE__VASPRINTF
+#cmakedefine HAVE_ASPRINTF
+#cmakedefine HAVE__ASPRINTF
+#cmakedefine HAVE_LOCALECONV
+#cmakedefine HAVE_VA_COPY
+#cmakedefine HAVE___VA_COPY
 
 #cmakedefine HAVE_MTX_INIT
 #cmakedefine HAVE_MTX_LOCK

--- a/src/utils/dsl.h
+++ b/src/utils/dsl.h
@@ -49,10 +49,10 @@
 
 
 /* Determine platform */
-#if defined __APPLE__ && defined __MARCH__
+#if defined __APPLE__ && defined __MACH__
 # define DSL_PLATFORM DSL_Posix
 # ifndef DSL_PREFIX
-#  define DSL_PREFIX ""
+#  define DSL_PREFIX "lib"
 # endif
 # ifndef DSL_EXT
 #  define DSL_EXT ".dylib"

--- a/src/utils/fileinfo.c
+++ b/src/utils/fileinfo.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <stdio.h>
 
-#if defined(__unix__)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 # ifndef POSIX
 #  define POSIX
 # endif

--- a/src/utils/fileutils.h
+++ b/src/utils/fileutils.h
@@ -22,7 +22,7 @@ enum {
 };
 
 
-#if defined __unix__ || (defined __APPLE__ && defined __MARCH__)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 /* POSIX */
 # ifndef POSIX
 #  define POSIX
@@ -65,7 +65,7 @@ typedef enum _FUPlatform {
   fuNative=0,            /*!< Platform we are compiling on */
   fuUnix,                /*!< Unix-like platforms; POSIX complient */
   fuWindows,             /*!< Windows */
-  fuApple,               /*!< Apple - not yet supported... */
+  fuApple,               /*!< Apple */
   fuLastPlatform         /*!< Must always be the last */
 } FUPlatform;
 


### PR DESCRIPTION
# Description
To allow compiling on MacOS, this update includes:
- Pre-processor updates.
- Switch changes for code handling files.

See #1060 for proposed changes.


## Commentary per file

### byteorder.h.in
- Added generated comment at top of file as a warning once processed.
- Including error in preprocessor `HAVE__BYTESWAP_*` (missing double underscore).
- Added MacOS equivalents of `endian.h` and `byteswap.h` plus defines to align naming of functions.

### getopt.h
- Moved `#ifndef _GETOPT_H_` after `#include` statement as original position prevented the loading of `getopt.h` (at least on MacOS).

### config.h.in
- Added HAVE_ defines that were set in the CMake config but unused in the codebase.
- Uncommented have statements as these were set in the CMake config.

### Remaining files
- Pre-processor updates.
- Switch changes for code handling files.
- Updated doxygen comments where function name was incorrect in `fileutils.c`.


## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
