### PR TITLE
Skip MinIO test when the MinIO playground is not responding or filled up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -*- Mode: cmake -*-
 #
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(dlite
   VERSION 0.5.26

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -117,6 +117,17 @@ if(FORCE_EXAMPLES OR EXISTS ${CMAKE_INSTALL_PREFIX}/share/dlite/examples)
 endif()
 
 
+# Special properties on minio_storage for not hanging when the MinIO
+# playground is not responding or when the storage is full
+set_property(TEST minio_storage APPEND PROPERTY
+  ENVIRONMENT "TIMEOUT=5"
+)
+set_property(TEST minio_storage PROPERTY
+  SKIP_REGULAR_EXPRESSION "(XMinioStorageFull)|(subprocess.TimeoutExpired)"
+)
+
+
+
 install(
   DIRECTORY ex1 ex2 ex3 ex4 ex5d read-csv dehydrogenation
   DESTINATION share/dlite/examples

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -114,17 +114,19 @@ if(FORCE_EXAMPLES OR EXISTS ${CMAKE_INSTALL_PREFIX}/share/dlite/examples)
       SKIP_RETURN_CODE 44)
   endforeach()
 
+
+  # Special properties on minio_storage for not hanging when the MinIO
+  # playground is not responding or when the storage is full
+  set_property(TEST minio_storage APPEND PROPERTY
+    ENVIRONMENT "TIMEOUT=5"
+  )
+  set_property(TEST minio_storage PROPERTY
+    SKIP_REGULAR_EXPRESSION "(XMinioStorageFull)|(subprocess.TimeoutExpired)"
+  )
+
 endif()
 
 
-# Special properties on minio_storage for not hanging when the MinIO
-# playground is not responding or when the storage is full
-set_property(TEST minio_storage APPEND PROPERTY
-  ENVIRONMENT "TIMEOUT=5"
-)
-set_property(TEST minio_storage PROPERTY
-  SKIP_REGULAR_EXPRESSION "(XMinioStorageFull)|(subprocess.TimeoutExpired)"
-)
 
 
 

--- a/examples/minio_storage/main.py
+++ b/examples/minio_storage/main.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import subprocess
 from pathlib import Path
@@ -10,5 +11,10 @@ importskip("minio")  # skip this test if minio is not available
 
 thisdir = Path(__file__).resolve().parent
 
-subprocess.check_call(args=[sys.executable, f"{thisdir}/store.py"])
-subprocess.check_call(args=[sys.executable, f"{thisdir}/fetch.py"])
+# Get timeout from the environment
+timeout_str = os.getenv("TIMEOUT", None)
+timeout = float(timeout_str) if timeout_str else None
+
+subprocess.check_call([sys.executable, f"{thisdir}/store.py"], timeout=timeout)
+subprocess.check_call([sys.executable, f"{thisdir}/fetch.py"], timeout=timeout)
+print(f"=== timeout={timeout} ===")

--- a/examples/minio_storage/main.py
+++ b/examples/minio_storage/main.py
@@ -17,4 +17,3 @@ timeout = float(timeout_str) if timeout_str else None
 
 subprocess.check_call([sys.executable, f"{thisdir}/store.py"], timeout=timeout)
 subprocess.check_call([sys.executable, f"{thisdir}/fetch.py"], timeout=timeout)
-print(f"=== timeout={timeout} ===")

--- a/storages/python/tests-python/CMakeLists.txt
+++ b/storages/python/tests-python/CMakeLists.txt
@@ -85,3 +85,9 @@ foreach(test ${python-tests})
   set_property(TEST ${test} PROPERTY SKIP_RETURN_CODE 44)
 
 endforeach()
+
+
+# Skip minio test if the minio playground storage is full
+set_property(TEST minio_storage PROPERTY
+  SKIP_REGULAR_EXPRESSION "XMinioStorageFull"
+)

--- a/storages/python/tests-python/CMakeLists.txt
+++ b/storages/python/tests-python/CMakeLists.txt
@@ -88,6 +88,6 @@ endforeach()
 
 
 # Skip minio test if the minio playground storage is full
-set_property(TEST minio_storage PROPERTY
+set_property(TEST test_minio PROPERTY
   SKIP_REGULAR_EXPRESSION "XMinioStorageFull"
 )


### PR DESCRIPTION
# Description
The MinIO tests often fails due to the MinIO playground not being available or its storage is filled up by other users.
Instead of failing the whole DLite test suite, it is highly preferable to just mark the MinIO tests as skipped in these cases. 

Tried to implement this PR at the CMake level to avoid unnecessary complicating the `minio_storage` example. However, CMake unfortunately doesn't support combining the TIMEOUT and SKIP_REGULAR_EXPRESSION test properties (as also noted by https://stackoverflow.com/questions/49153984/non-failing-timeout-using-ctest), so timeout was moved to Python.

We currently have not timeout in the `test_minio` cmake test since dlite.Storage doesn't implement timeout. Issue #1067 has been added to address that. 

Also bumped up the CMake requirements to 3.16 such that we can use the SKIP_REGULAR_EXPRESSION test property.



## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
