### PR TITLE
Added a possible workaround for the failure in oteapi-dlite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(dlite
-  VERSION 0.5.26
+  VERSION 0.5.27
   DESCRIPTION "Lightweight data-centric framework for semantic interoperability"
   HOMEPAGE_URL "https://github.com/SINTEF/dlite"
   LANGUAGES C

--- a/src/dlite-collection.c
+++ b/src/dlite-collection.c
@@ -45,7 +45,7 @@ int dlite_collection_deinit(DLiteInstance *inst)
   while ((r=dlite_collection_find(coll,&state, NULL, "_has-uuid", NULL,
                                   NULL))) {
     if ((inst2 = dlite_instance_get(r->o))) {
-      dlite_instance_decref(inst2);  // remove ref from collection
+      //dlite_instance_decref(inst2);  // remove ref from collection
       dlite_instance_decref(inst2);  // remove local ref to inst2
     } else {
       warnx("cannot remove missing instance: %s", r->o);


### PR DESCRIPTION
# Description
This doesn't look like the right solution. If it solves the problem in oteapi the issue is probably a missing incref() in when the instance is added to the collection.

## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
