### PR TITLE
Return a new reference when iterating over a collection.

### DIFF
--- a/bindings/python/dlite-collection.i
+++ b/bindings/python/dlite-collection.i
@@ -158,7 +158,7 @@ struct _DLiteCollection {
   }
 
   %feature("docstring",
-           "Returns a reference to next matching relation."
+           "Returns a new reference to next matching relation."
            ) next;
   const struct _DLiteInstance *next(void) {
     return dlite_collection_next_new($self->coll, &$self->state);

--- a/bindings/python/dlite-collection.i
+++ b/bindings/python/dlite-collection.i
@@ -157,6 +157,7 @@ struct _DLiteCollection {
     free($self);
   }
 
+  %newobject next;
   %feature("docstring",
            "Returns a new reference to next matching relation."
            ) next;

--- a/bindings/python/dlite-collection.i
+++ b/bindings/python/dlite-collection.i
@@ -159,7 +159,7 @@ struct _DLiteCollection {
 
   %newobject next;
   %feature("docstring",
-           "Returns a new reference to next matching relation."
+           "Returns a new reference next instance in the collection."
            ) next;
   const struct _DLiteInstance *next(void) {
     return dlite_collection_next_new($self->coll, &$self->state);

--- a/bindings/python/dlite-collection.i
+++ b/bindings/python/dlite-collection.i
@@ -161,7 +161,7 @@ struct _DLiteCollection {
            "Returns a reference to next matching relation."
            ) next;
   const struct _DLiteInstance *next(void) {
-    return dlite_collection_next($self->coll, &$self->state);
+    return dlite_collection_next_new($self->coll, &$self->state);
   }
 
   %feature("docstring",

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(tests
   test_python_bindings
   test_collection
   test_collection_load
+  test_collection_refcount
   test_entity
   test_factory
   test_misc

--- a/bindings/python/tests/test_collection_refcount.py
+++ b/bindings/python/tests/test_collection_refcount.py
@@ -6,42 +6,52 @@ def add_blob(coll):
     """Adds a blob instance to the collection."""
     Blob = dlite.get_instance("http://onto-ns.com/meta/0.1/Blob")
     blob = Blob([10])
+    blob2 = Blob([2])
     coll.add("blob", blob)
-    return coll
+    coll.add("blob2", blob2)
+
 
 def use_blob(coll):
     """Access the blob instance in the collection."""
     blob = coll.get("blob")
-    assert blob._refcount == 2
-    return coll
+    assert blob._refcount == 3  # coll, local blob, global blob
+
 
 def use_blob2(coll):
     """Access the blob instance in the collection."""
-    blob = next(coll.get_instances())
-    assert blob._refcount == 2
-    return coll
+    blob, blob2 = coll.get_instances()
+    assert blob._refcount == 3  # coll, local blob, global blob
+    assert blob2._refcount == 2  # coll, local blob2
 
 
 coll = dlite.Collection()
 assert coll._refcount == 1
-coll2 = add_blob(coll)
-assert coll._refcount == 1
-assert coll2._refcount == 1
-use_blob(coll)
-use_blob(coll)
-use_blob2(coll)
+
+add_blob(coll)
 assert coll._refcount == 1
 
 blob = coll.get("blob")
-assert blob._refcount == 3  # 2
+assert blob._refcount == 2  # coll, blob
+
+use_blob(coll)
+use_blob(coll)
+assert coll._refcount == 1
+assert blob._refcount == 2  # coll, blob
+
+use_blob2(coll)
+assert coll._refcount == 1
+assert blob._refcount == 3  # 2 - coll, blob
+
+#use_blob2(coll)
+#assert blob._refcount == 3  # 2
 
 
 insts = list(coll.get_instances())
 inst = insts[0]
-assert inst._refcount == 4  # 3
+assert inst._refcount == 4  # 3 - inst, blob, coll
 
-del coll, coll2
-assert inst._refcount == 3  # 2
+del coll
+assert inst._refcount == 3  # 2 - inst, blob
 
 del blob
-assert inst._refcount == 2  # 1
+assert inst._refcount == 2  # 1 - inst

--- a/bindings/python/tests/test_collection_refcount.py
+++ b/bindings/python/tests/test_collection_refcount.py
@@ -1,9 +1,16 @@
-"""A test that tries to reproduce what happens in oteapi-dlite."""
+"""Test that the reference counting of instances added to a collection
+is working properly.
+
+The test ensures that the reference count is increased when new
+references are created and decreased when the references goes out of
+scope or are deleted.
+
+"""
 import dlite
 
 
 def add_blob(coll):
-    """Adds a blob instance to the collection."""
+    """Adds two blob instances to the collection."""
     Blob = dlite.get_instance("http://onto-ns.com/meta/0.1/Blob")
     blob = Blob([10])
     blob2 = Blob([2])
@@ -12,13 +19,13 @@ def add_blob(coll):
 
 
 def use_blob(coll):
-    """Access the blob instance in the collection."""
+    """Access instance using the Collection.get() method."""
     blob = coll.get("blob")
     assert blob._refcount == 3  # coll, local blob, global blob
 
 
 def use_blob2(coll):
-    """Access the blob instance in the collection."""
+    """Access instances using the Collection.get_instances() method."""
     blob, blob2 = coll.get_instances()
     assert blob._refcount == 3  # coll, local blob, global blob
     assert blob2._refcount == 2  # coll, local blob2

--- a/bindings/python/tests/test_collection_refcount.py
+++ b/bindings/python/tests/test_collection_refcount.py
@@ -1,0 +1,47 @@
+"""A test that tries to reproduce what happens in oteapi-dlite."""
+import dlite
+
+
+def add_blob(coll):
+    """Adds a blob instance to the collection."""
+    Blob = dlite.get_instance("http://onto-ns.com/meta/0.1/Blob")
+    blob = Blob([10])
+    coll.add("blob", blob)
+    return coll
+
+def use_blob(coll):
+    """Access the blob instance in the collection."""
+    blob = coll.get("blob")
+    assert blob._refcount == 2
+    return coll
+
+def use_blob2(coll):
+    """Access the blob instance in the collection."""
+    blob = next(coll.get_instances())
+    assert blob._refcount == 2
+    return coll
+
+
+coll = dlite.Collection()
+assert coll._refcount == 1
+coll2 = add_blob(coll)
+assert coll._refcount == 1
+assert coll2._refcount == 1
+use_blob(coll)
+use_blob(coll)
+use_blob2(coll)
+assert coll._refcount == 1
+
+blob = coll.get("blob")
+assert blob._refcount == 3  # 2
+
+
+insts = list(coll.get_instances())
+inst = insts[0]
+assert inst._refcount == 4  # 3
+
+del coll, coll2
+assert inst._refcount == 3  # 2
+
+del blob
+assert inst._refcount == 2  # 1

--- a/bindings/python/tests/test_collection_refcount.py
+++ b/bindings/python/tests/test_collection_refcount.py
@@ -40,18 +40,18 @@ assert blob._refcount == 2  # coll, blob
 
 use_blob2(coll)
 assert coll._refcount == 1
-assert blob._refcount == 3  # 2 - coll, blob
+assert blob._refcount == 2  # coll, blob
 
-#use_blob2(coll)
-#assert blob._refcount == 3  # 2
+use_blob2(coll)
+assert blob._refcount == 2  # coll, blob
 
 
 insts = list(coll.get_instances())
 inst = insts[0]
-assert inst._refcount == 4  # 3 - inst, blob, coll
+assert inst._refcount == 3  # inst, blob, coll
 
 del coll
-assert inst._refcount == 3  # 2 - inst, blob
+assert inst._refcount == 2  # inst, blob
 
 del blob
-assert inst._refcount == 2  # 1 - inst
+assert inst._refcount == 1  # inst

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -22,7 +22,7 @@ urllib3>=1.0.0,<2
 #psycopg2>=2,<3
 
 # Utilities
-# Bug in pydantic 2.10.0, see https://github.com/pydantic/pydantic/issues/9898
+# Bug in pydantic 2.10.0, 2.10.1: See https://github.com/pydantic/pydantic/issues/9898
 annotated-types>=0.5.0,<0.8.0
 pydantic>=1.10.0,!=2.10.0,!=2.10.1,<2.10.6
 pydantic-core>=0.42,<2.27.3


### PR DESCRIPTION
# Description
Return a new reference when iterating over a collection and ensure that it is decreased again when the instances goes out of scope (memory managed by dlite).

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
