### PR TITLE
Reverting manylinux wheel from 2_34 to 2_28

### DIFF
--- a/.github/docker/Dockerfile-manylinux_x_y.template
+++ b/.github/docker/Dockerfile-manylinux_x_y.template
@@ -17,21 +17,21 @@
 #
 # Generate dockerfile:
 #
-#     .github/docker/gen_dockerfile.sh manylinux _2_34 x86_64 > \
-#         .github/docker/dockerfiles/Dockerfile-manylinux_2_34_x86_64
+#     .github/docker/gen_dockerfile.sh manylinux _2_28 x86_64 > \
+#         .github/docker/dockerfiles/Dockerfile-manylinux_2_28_x86_64
 #
 # Build:
 #
 #     cd dlite  # cd to DLite root directory
-#     docker build -t dlite-manylinux_2_34_x86_64 \
-#         -f .github/docker/dockerfiles/Dockerfile-manylinux_2_34_x86_64 .
+#     docker build -t dlite-manylinux_2_28_x86_64 \
+#         -f .github/docker/dockerfiles/Dockerfile-manylinux_2_28_x86_64 .
 #
 # Run (for debugging):
 #
 #     docker run --rm -it \
 #         --volume $PWD:/io \
 #         --user $(id -u):$(id -g) \
-#         dlite-manylinux_2_34_x86_64 \
+#         dlite-manylinux_2_28_x86_64 \
 #         /bin/bash
 #
 

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -78,7 +78,7 @@ jobs:
 
           # 64-bit manylinux
           - os: ubuntu-20.04
-            system_type: ["manylinux", "_2_34"]
+            system_type: ["manylinux", "_2_28"]
             arch: x86_64
             py_minors: 8,9,10,11,12,13
 

--- a/.github/workflows/ci_build_wheels.yml
+++ b/.github/workflows/ci_build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
 
           # 64-bit manylinux
           - os: ubuntu-20.04
-            system_type: ["manylinux", "_2_34"]
+            system_type: ["manylinux", "_2_28"]
             arch: x86_64
             py_minors: 8,13
 

--- a/.github/workflows/container_builds_weekly.yml
+++ b/.github/workflows/container_builds_weekly.yml
@@ -24,7 +24,7 @@ jobs:
         include:
         # 64-bit manylinux
         - system: "manylinux"
-          type: "_2_34"
+          type: "_2_28"
           arch: "x86_64"
           py_minors: "8 9 10 11 12 13"
         #- system: "manylinux"


### PR DESCRIPTION
# Description
Reverting manylinux wheel from 2_34 to 2_28.

Reason: Building with manylinux_2_34 fails. Also, on https://cibuildwheel.pypa.io/en/stable/options/ they no more refer to manylinux_2_34. manylinux_2_28 will be the new default after manylinux_2014. It is also the highest version that they refer to (except for 2_31, but that is only for ARMv7).

## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
