### PR TITLE
Update ubuntu for ci

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   update_version:
     name: Update DLite version and release body
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
     steps:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   update_version:
     name: Update DLite version and release body
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -77,25 +77,25 @@ jobs:
           # See ci_build_wheel.yml for a tested matrix of working combinations
 
           # 64-bit manylinux
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["manylinux", "_2_28"]
             arch: x86_64
             py_minors: 8,9,10,11,12,13
 
           # 64-bit musllinux
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["musllinux", "_1_2"]
             arch: x86_64
             py_minors: 8,9,10,11,12,13
 
           # 32-bit manylinux
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["manylinux", "2014"]
             arch: i686
             py_minors: 10,11,12,13
 
           # 32-bit musllinux
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["musllinux", "_1_2"]
             arch: i686
             py_minors: 9,10,11

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -161,7 +161,7 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'SINTEF/dlite' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -202,7 +202,7 @@ jobs:
   publish:
     needs: [cd_build_wheels,build_sdist]
     name: Publish DLite distributions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
 

--- a/.github/workflows/ci_build_wheels.yml
+++ b/.github/workflows/ci_build_wheels.yml
@@ -19,20 +19,20 @@ jobs:
         include:
 
           # 64-bit manylinux
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["manylinux", "_2_28"]
             arch: x86_64
             py_minors: 8,13
 
           # 64-bit musllinux
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["musllinux", "_1_2"]
             arch: x86_64
             py_minors: 8,13
 
           # 32-bit manylinux
           # Python 3.8 does not have numpy2
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["manylinux", "2014"]
             arch: i686
             py_minors: 10,13
@@ -40,13 +40,13 @@ jobs:
           # 32-bit musllinux
           # Python 3.8 does not have numpy2
           # Python 3.12 fails since cibuildwheel still depends on distutils
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             system_type: ["musllinux", "_1_2"]
             arch: i686
             py_minors: 9,11
 
           # 64-bit Windows
-          - os: windows-2019
+          - os: windows-2022
             system_type: ["win", ""]
             arch: amd64
             py_minors: 8,13

--- a/doc/user_guide/concepts.md
+++ b/doc/user_guide/concepts.md
@@ -245,13 +245,14 @@ the table below list the three representations of identifiers. Any
 representation can be considered an ID, while normalised IDs are valid
 IRIs.
 
-| ID             | Normalised ID  | Corresponding UUID    | Note          |
-|----------------|----------------|-----------------------|---------------|
-| *uuid*         | *ns* / *uuid*  | *uuid*                |               |
-| *uri* / *uuid* | *uri* / *uuid* | *uuid*                |               |
-| *uri*          | *uri*          | hash of *uri*         |               |
-| *name*         | *ns* / *name*  | hash of *name*        | before v0.6.0 |
-| *name*         | *ns* / *name*  | hash of *ns* / *name* | v0.6.0+       |
+| ID             | Normalised ID  | Corresponding UUID    | Note                        |
+|----------------|----------------|-----------------------|-----------------------------|
+| *uuid*         | *ns* / *uuid*  | *uuid*                |                             |
+| *uri* / *uuid* | *uri* / *uuid* | *uuid*                |                             |
+| *uri*          | *uri*          | hash of *uri*         |                             |
+| *name*         | *ns* / *name*  | hash of *name*        | experimental, before v0.6.0 |
+| *name*         | *ns* / *name*  | hash of *ns* / *name* | experimental, v0.6.0+       |
+|                |                |                       |                             |
 
 **Explanation of the symbols used in the table**
 
@@ -262,6 +263,8 @@ IRIs.
 - *name* is a string that is neither a UUID or a URL. Ex: "aa6060".
 
 ```{note}
+The support of name IDs is considered experimental!
+
 The way a UUID is calculated from an ID of the form of a *name* was changed
 in version 0.6.0.
 


### PR DESCRIPTION
# Description
Update Ubuntu to from 20.04 to 24.04 in the `ci_build_wheels` and `cd_release` workflows.
We use explicit version numbers to avoid surprising changes.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
