### PR TITLE
Implicit metadata dimensions

### DIFF
--- a/bindings/python/scripts/CMakeLists.txt
+++ b/bindings/python/scripts/CMakeLists.txt
@@ -79,7 +79,7 @@ test_success(
 )
 
 # The "dimensions" keyword is required
-test_failure(
+test_success(
   dlite-validate-no-dimensions
   dlite-validate NoDimensions.json
 )

--- a/bindings/python/tests/test_entity.py
+++ b/bindings/python/tests/test_entity.py
@@ -134,7 +134,7 @@ with raises(dlite.DLiteStorageLoadError):
     Instance.from_location("json", "non-existing-path...")
 
 
-# Test for issue #352 - improved error message for missing dimensions
+# Test for implicit metadata dimensions
 json_repr = """
 {
   "uri": "http://onto-ns.com/ex/0.1/test",
@@ -145,8 +145,10 @@ json_repr = """
   }
 }
 """
-with raises(dlite.DLiteParseError):
-    dlite.Instance.from_json(json_repr)
+meta = dlite.Instance.from_json(json_repr)
+assert meta.ndimensions == 0
+assert meta.nproperties == 1
+assert meta.getprop("x").type == "int64"
 
 
 # Test copy

--- a/doc/user_guide/concepts.md
+++ b/doc/user_guide/concepts.md
@@ -200,6 +200,11 @@ they are accessed from the same namespace.
 A metadata dimension simply provides a *name* and a human *description* of a
 given dimension of an array property.
 
+**Convention**: For metadata schemata, should the dimension names start with an
+"n" followed by the name of a property how's length is defined by the dimension.
+For example, the dimension that determine the number of properties in a metadata
+schema should be named "nproperties".
+
 
 ### Property
 A property describes an element or item of an instance and has the following
@@ -212,12 +217,17 @@ attributes:
 - *shape*: The dimensions of multi-dimensional properties.
   This is a list of dimension expressions referring to the dimensions defined above.
   For instance, if a data model have dimensions with names `H`, `K` and `L` and
-  a property with shape `["K", "H+1"]`, the property of an instance of this data model
-  with dimension values `H=2, K=2, L=6` will have shape `[2, 3]`.
+  a property with shape `["K", "H+1"]`, the property of an instance of this data
+  model with dimension values `H=2, K=2, L=6` will have shape `[2, 3]`.
 - *unit*: The unit of the property.
 - *description*: A human description of the property.
 
 Please note that *dims* is a now deprecated alias for *shape*.
+
+**Convention**: If a metadata schema has an array property of type 'dimension',
+'property' or 'relation', it should be named "dimensions", "properties" and
+"relations", respectively.  Their shape should be `["ndimensions"]`,
+`["nproperties"]` and `["nrelations"]`, respectively.
 
 
 ### Relation


### PR DESCRIPTION
# Description
Allow to omit "dimensions", "properties" and/or "relations" in metadata. They default to be the empty array.

Also updated tests and documentation.

## Type of change
- [ ] Bug fix & code cleanup
- [x] New feature
- [x] Documentation update
- [x] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
