### PR TITLE
Docs: Fix some warnings from Sphinx

### DIFF
--- a/bindings/python/python-protocol-plugins/zip.py
+++ b/bindings/python/python-protocol-plugins/zip.py
@@ -20,6 +20,7 @@ class zip(dlite.DLiteProtocolBase):
             location: A URL or path to a zip file.
                 If `location` is a URL, a local cache is created and reused.
             options: The following options are supported:
+
                 - timeout: Number of seconds before timing out when downloading
                   an URL.
                 - nocache: If true and path is a URL, the zip file will be

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -393,7 +393,7 @@ INLINE_SIMPLE_STRUCTS  = NO
 # types are typedef'ed and only the typedef is referenced, never the tag name.
 # The default value is: NO.
 
-TYPEDEF_HIDES_STRUCT   = NO
+TYPEDEF_HIDES_STRUCT   = YES
 
 # The size of the symbol lookup cache can be set using LOOKUP_CACHE_SIZE. This
 # cache is used to resolve symbols given their name and scope. Since this can be
@@ -833,6 +833,7 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */tests/test_* \
+                         */tests/* \
                          */old/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
@@ -930,8 +931,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-#USE_MDFILE_AS_MAINPAGE = @dlite_SOURCE_DIR@/README.md
-USE_MDFILE_AS_MAINPAGE = @CMAKE_CURRENT_BINARY_DIR@/README.md
+USE_MDFILE_AS_MAINPAGE = 
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1156,15 +1156,6 @@ HTML_COLORSTYLE_SAT    = 100
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_COLORSTYLE_GAMMA  = 80
-
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
@@ -1729,14 +1720,6 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output

--- a/doc/contributors_guide/tips_and_tricks.md
+++ b/doc/contributors_guide/tips_and_tricks.md
@@ -171,7 +171,7 @@ to rerun valgrind on that issue, you can run
 
 Both of the above commands will write the output to `<BUILD_DIR>/Testing/Temporary/MemoryChecker.<#>.log`, where `<#>` is the test number.
 
-```note
+```{note}
 The first time you run `make memcheck`, a supression file will be created, suppressing issues that does not comes from DLite.
 Generating a suppression file may take long time, but it will only be generated once unless you manually add more suppressions to one of the `cmake/valgrind-*.supp` files.
 ```

--- a/doc/getting_started/tutorial.md
+++ b/doc/getting_started/tutorial.md
@@ -384,7 +384,7 @@ You can use the method `person.set_quantity` to set a property with a quantity o
 
 ```
 
-```note
+```{note}
 If you need in your program to use a specific units registry, use the function
 [`pint.set_application_registry()`]
 ```

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,6 @@ DLite
 
    getting_started/index
    user_guide/index
-   api_reference/index
    contributors_guide/index
    license
 

--- a/doc/respirator.py
+++ b/doc/respirator.py
@@ -24,7 +24,7 @@ class DoxygenXML:
                  output_path: Union[str,Path],
                  template_path: Union[str, Path],
                  index_file = 'index.xml',
-                 filename_filter=".*\.h"):
+                 filename_filter=r".*\.h"):
         """
         initialize class
         """


### PR DESCRIPTION
# Description

Tidy up some of the warnings in the output from Sphinx. Fixes:

- .../build/doc/_build/c-api/src/utils.rst:37: WARNING: toctree contains reference to nonexisting document 'c-api/src/utils/tests' [toc.not_readable]
- Warnings for obsolete settings from Doxygen configuration file
- Warning "Specified markdown mainpage ... does not exist"
- Warning: toctree contains reference to nonexisting document 'api_reference/index' [toc.not_readable]
- SyntaxWarning: invalid escape sequence '\.'
- Pygments lexer name 'note' is not known [misc.highlighting_failure]
- Error Unexpected indentation. [docutils]
- Various C++ warnings



For the last item in the list, when building the docs with the Doxyfile setting `TYPEDEF_HIDES_STRUCT`, it can be seen the output is neater with the following example in [dlite-arrays](https://sintef.github.io/dlite/c-api/src/dlite-arrays.html).

`typedef struct _DLiteArray DLiteArray` is omitted leaving just `struct DLiteArray` with the correct docstring and the public member listing).


## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [x] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
