### PR TITLE
Fix memory warnings reviled by latest cppcheck

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -37,14 +37,19 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.8"
             subsystem: none
+            testargs: ""
           - os: ubuntu-latest
             python-version: "3.13"
             subsystem: none
+            testargs: ""
           - os: windows-latest
             python-version: "3.10"
             subsystem: none
+            # Installation of cppcheck seems to be broken on Windows at the moment...
+            testargs: "-E static-code-analysis"
           - os: windows-latest
             subsystem: mingw
+            testargs: ""
 
     steps:
       - name: Setup MSYS2
@@ -277,7 +282,7 @@ jobs:
           then
             source ../venv/bin/activate
           fi
-          ctest --build-config Release || ctest --build-config Release --rerun-failed --output-on-failure -V
+          ctest --build-config Release ${{ matrix.testargs }} || ctest --build-config Release --rerun-failed --output-on-failure -V ${{ matrix.testargs }}
 
 
       - name: Test with all behavior changes disabled
@@ -289,7 +294,7 @@ jobs:
           then
             source ../venv/bin/activate
           fi
-          ctest --build-config Release || ctest --build-config Release --rerun-failed --output-on-failure -V
+          ctest --build-config Release ${{ matrix.testargs }} || ctest --build-config Release --rerun-failed --output-on-failure -V ${{ matrix.testargs }}
 
 
       - name: Test with all behavior changes enabled
@@ -301,7 +306,7 @@ jobs:
           then
             source ../venv/bin/activate
           fi
-          ctest --build-config Release || ctest --build-config Release --rerun-failed --output-on-failure -V
+          ctest --build-config Release ${{ matrix.testargs }} || ctest --build-config Release --rerun-failed --output-on-failure -V ${{ matrix.testargs }}
 
 
       - name: Build ${{ matrix.os }} wheel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,10 +619,15 @@ if(CPPCHECK)
     set(cppcheck_ignore_options "${cppcheck_ignore_options} -i ${dir}")
   endforeach()
 
+  # Bug in cppcheck 2.18.3
+  # We have to use --check-level=exhaustive to get rid of information output.
+  # Otherwise there will be a lot of information output which will make the
+  # test failing.
   add_test(
     NAME static-code-analysis
     COMMAND ${CPPCHECK}
-      --language=c -q --force --error-exitcode=2 --inline-suppr
+      --language=c -q --error-exitcode=2 --inline-suppr --force
+      --disable=information --check-level=exhaustive
       --cppcheck-build-dir=${dlite_BINARY_DIR}/cppcheck
       -i build -i python ${cppcheck_ignore_options}
       -I${dlite_SOURCE_DIR}/src -I${dlite_BINARY_DIR}/src

--- a/examples/ex3/main.c
+++ b/examples/ex3/main.c
@@ -11,6 +11,7 @@ char* fvname(char* phase){
    char* tail = ")";
    char* string = (char*)malloc(1+strlen(head)+strlen(phase)+strlen(tail));
 
+   if (!string) return NULL;
    strcpy(string, head);
    strcat(string, phase);
    strcat(string, tail);
@@ -26,6 +27,7 @@ char* xname(char* phase,char* element){
    char* tail = ")";
    char* string = (char*)malloc(1+strlen(head)+strlen(phase)+strlen(middle)+strlen(element)+strlen(tail));
 
+   if (!string) return NULL;
    strcpy(string, head);
    strcat(string, phase);
    strcat(string, middle);

--- a/examples/ex5d/example5d.c
+++ b/examples/ex5d/example5d.c
@@ -139,6 +139,13 @@ main(int argc, char *argv)
   sname=malloc(TC_STRLEN_MAX);
   components=malloc(TC_MAX_NR_OF_ELEMENTS*sizeof(tc_components_strings));
 
+  /* needed to make cppcheck happy */
+  assert(iwsg);
+  assert(iwse);
+  assert(phname);
+  assert(sname);
+  assert(components);
+
   memset(iwsg,0,sizeof(TC_INT)*TC_NWSG);
   memset(iwse,0,sizeof(TC_INT)*TC_NWSE);
   memset(log_file_directory,0,sizeof(log_file_directory));

--- a/src/dlite-entity.c
+++ b/src/dlite-entity.c
@@ -1871,6 +1871,7 @@ int dlite_instance_set_dimension_size_by_index(DLiteInstance *inst,
   size_t j;
   int retval;
   int *dims = malloc(inst->meta->_ndimensions * sizeof(int));
+  if (!dims) return err(dliteMemoryError, "allocation failure");
   for (j=0; j < inst->meta->_ndimensions; j++) dims[j] = -1;
   dims[i] = size;
   retval = dlite_instance_set_dimension_sizes(inst, dims);
@@ -2118,6 +2119,7 @@ char *dlite_instance_default_uri(const DLiteInstance *inst)
 {
   int n = strlen(inst->meta->uri);
   char *buf = malloc(n + DLITE_UUID_LENGTH + 2);
+  if (!buf) return err(dliteMemoryError, "allocation failure"), NULL;
   memcpy(buf, inst->meta->uri, n);
   buf[n] = '/';
   memcpy(buf+n+1, inst->uuid, DLITE_UUID_LENGTH);

--- a/src/tests/test_collection.c
+++ b/src/tests/test_collection.c
@@ -238,10 +238,11 @@ MU_TEST(test_collection_load)
   DLiteCollection *coll2;
   char *collpath = STRINGIFY(dlite_SOURCE_DIR) "/src/tests/coll.json";
   FILE *fp = fopen(collpath, "r");
+  mu_check(fp);
   dlite_storage_paths_append(STRINGIFY(dlite_SOURCE_DIR) "/src/tests/*.json");
   coll2 = (DLiteCollection *)
     dlite_json_fscan(fp, NULL, "http://onto-ns.com/meta/0.1/Collection");
-  fclose(fp);  // cppcheck-suppress nullPointerOutOfResources
+  fclose(fp);
 
   dlite_collection_decref(coll2);
 }

--- a/src/tests/test_collection.c
+++ b/src/tests/test_collection.c
@@ -241,7 +241,7 @@ MU_TEST(test_collection_load)
   dlite_storage_paths_append(STRINGIFY(dlite_SOURCE_DIR) "/src/tests/*.json");
   coll2 = (DLiteCollection *)
     dlite_json_fscan(fp, NULL, "http://onto-ns.com/meta/0.1/Collection");
-  fclose(fp);
+  fclose(fp);  // cppcheck-suppress nullPointerOutOfResources
 
   dlite_collection_decref(coll2);
 }

--- a/src/tests/test_dlitebson.c
+++ b/src/tests/test_dlitebson.c
@@ -26,6 +26,7 @@ MU_TEST(test_write_meta)
   mu_assert_int_eq(bson_docsize(doc), n);
 
   FILE *fp = fopen("test-entity.bson", "wb");
+  mu_check(fp);
   fwrite(doc, n, 1, fp);
   fclose(fp);
 }
@@ -48,6 +49,7 @@ MU_TEST(test_write_instance)
   mu_assert_int_eq(bson_docsize(doc), n);
 
   FILE *fp = fopen("test-data.bson", "wb");
+  mu_check(fp);
   fwrite(doc, n, 1, fp);
   fclose(fp);
 
@@ -60,6 +62,7 @@ MU_TEST(test_load_instance)
   unsigned char doc[1024];
 
   FILE *fp = fopen("test-data.bson", "rb");
+  mu_check(fp);
   fread(doc, 1, sizeof(doc), fp);
   fclose(fp);
 
@@ -79,6 +82,7 @@ MU_TEST(test_load_meta)
   unsigned char doc[4096];
   char *path = STRINGIFY(dlite_SOURCE_DIR) "/src/tests/Chemistry.bson";
   FILE *fp = fopen(path, "rb");
+  mu_check(fp);
   fread(doc, 1, sizeof(doc), fp);
   fclose(fp);
 

--- a/src/tests/test_json.c
+++ b/src/tests/test_json.c
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -122,6 +123,7 @@ MU_TEST(test_sprint)
 int append(const char *str)
 {
   char *s = strdup(str);
+  assert(s);
   size_t size = strlen(s) + 1;
   int m, retval=0;
   //printf("\n--- append: '%s' ---\n", str);

--- a/src/triplestore-redland.c
+++ b/src/triplestore-redland.c
@@ -501,6 +501,7 @@ static librdf_node *new_uri_node(TripleStore *ts, const char *uri)
     size_t len_ns = strlen(ts->ns);
     size_t len_uri = strlen(uri);
     unsigned char *buf = malloc(len_ns + len_uri + 2);
+    if (!buf) return err(dliteMemoryError, "allocation failure"), NULL;
     memcpy(buf, ts->ns, len_ns);
     buf[len_ns] = ':';
     memcpy(buf + len_ns + 1, uri, len_uri + 1);

--- a/src/utils/compat-src/snprintf.c
+++ b/src/utils/compat-src/snprintf.c
@@ -1487,7 +1487,7 @@ mymemcpy(void *dst, void *src, size_t len)
 	/* No need for optimization, we use this only to replace va_copy(3). */
 	while (len-- > 0)
 		*to++ = *from++;
-	return dst;
+	return dst;  // cppcheck-suppress uninitvar
 }
 #endif	/* NEED_MYMEMCPY */
 

--- a/src/utils/plugin.c
+++ b/src/utils/plugin.c
@@ -341,6 +341,10 @@ const PluginAPI *plugin_get_api(PluginInfo *info, const char *name, int errcode)
 void plugin_load_all(PluginInfo *info)
 {
   char *pattern = malloc(strlen(DSL_EXT) + 2);
+  if (!pattern) {
+    err(pluginMemoryError, "allocation failure");
+    return;
+  }
   pattern[0] = '*';
   strcpy(pattern+1, DSL_EXT);
   while (1)

--- a/src/utils/tests/test_bson.c
+++ b/src/utils/tests/test_bson.c
@@ -215,6 +215,7 @@ MU_TEST(test_append_binary)
   mu_assert_int_eq(bson_docsize(doc), n);
 
   FILE *fp = fopen("test-append-binary.bson", "wb");
+  mu_check(fp);
   fwrite(doc, n, 1, fp);
   fclose(fp);
 }

--- a/src/utils/tests/test_snprintf.c
+++ b/src/utils/tests/test_snprintf.c
@@ -45,6 +45,8 @@ MU_TEST(test_snprintf)
   char *long_string = strdup("0123456789abcdef");
   int n;
 
+  mu_check(long_string);
+
   printf("\n\n--- test_snprintf\n");
   n = snprintf(buf, sizeof(buf), "%s", short_string);
   mu_assert_int_eq(strlen(short_string), n);

--- a/storages/python/README.md
+++ b/storages/python/README.md
@@ -110,8 +110,6 @@ install and setup a postgresql server on Fedora. Short instructions:
     postgres=# CREATE USER my_username WITH PASSWORD 'my_password';
     postgres=# CREATE DATABASE my_database OWNER my_username;
 
-
-
 The `test_postgresql`_storage test require local configurations of the
 PostgreSQL server.  The test is only enabled if a file pgconf.h can be
 found in the [tests-c/](tests-c/) sub-directory.  Example pgconf.h file:

--- a/storages/python/README.md
+++ b/storages/python/README.md
@@ -94,7 +94,7 @@ blob
 Specialised plugin for reading and writing a binary blob to file.  The
 content is specified using the metadata
 http://onto-ns.com/meta/0.1/Blob (defined in the json file
-[$DLITE_SOURCE_DIR/storages/python/python-storage-plugins/blob.json](https://github.com/SINTEF/dlite/blob/master/storages/python/python-storage-plugins/blob.json)). 
+[$DLITE_SOURCE_DIR/storages/python/python-storage-plugins/blob.json](https://github.com/SINTEF/dlite/blob/master/storages/python/python-storage-plugins/blob.json)).
 It will be installed in the default metadata search path and seamless
 accessible.
 
@@ -104,11 +104,17 @@ postgresql
 Generic plugin for reading and writing to a PostgreSQL database.
 
 See https://docs.fedoraproject.org/en-US/quick-docs/postgresql/ for how to
-install and setup a postgresql server on Fedora.
+install and setup a postgresql server on Fedora. Short instructions:
 
-The test_postgresql_storage test require local configurations of the
+    sudo -u postgres psql
+    postgres=# CREATE USER my_username WITH PASSWORD 'my_password';
+    postgres=# CREATE DATABASE my_database OWNER my_username;
+
+
+
+The `test_postgresql`_storage test require local configurations of the
 PostgreSQL server.  The test is only enabled if a file pgconf.h can be
-found in the [tests-c/](tests-c/) sub-directory with the following content:
+found in the [tests-c/](tests-c/) sub-directory.  Example pgconf.h file:
 
     #define HOST "pg_server_host"
     #define USER "my_username"

--- a/storages/python/dlite-plugins-python.c
+++ b/storages/python/dlite-plugins-python.c
@@ -186,6 +186,7 @@ char *helper(const DLiteStoragePlugin *api)
 {
   PyObject *v=NULL, *pyclassdoc=NULL, *open=NULL, *pyopendoc=NULL;
   PyObject *class = (PyObject *)api->data;
+  PyObject *inspect=NULL, *getdoc=NULL;
   const char *classname, *classdoc=NULL, *opendoc=NULL;
   char *doc=NULL;
   Py_ssize_t n=0, clen=0, olen=0, i, newlines=0;
@@ -212,7 +213,6 @@ char *helper(const DLiteStoragePlugin *api)
       //
       // Aligns pre-Python 3.13 behaviour with new behaviour which was
       // implemented into CPython in: https://github.com/python/cpython/pull/106411
-      PyObject *inspect=NULL, *getdoc=NULL;
       if (!(inspect = PyImport_ImportModule("inspect")))
         FAILCODE(dliteAttributeError, "cannot import inspect module");
       if (!((getdoc = PyObject_GetAttrString(inspect, "getdoc")) && PyCallable_Check(getdoc)))
@@ -220,6 +220,8 @@ char *helper(const DLiteStoragePlugin *api)
       if (!(pyopendoc = PyObject_CallFunctionObjArgs(getdoc, open, NULL)))
         FAILCODE1(dliteAttributeError, "cannot call inspect.getdoc() with %s.open", classname);
 #else
+      UNUSED(getdoc);
+      UNUSED(inspect);
       if (!(pyopendoc = PyObject_GetAttrString(open, "__doc__")))
         FAILCODE1(dliteAttributeError, "cannot access %s.open.__doc__",
                   classname);

--- a/storages/python/dlite-plugins-python.c
+++ b/storages/python/dlite-plugins-python.c
@@ -186,7 +186,6 @@ char *helper(const DLiteStoragePlugin *api)
 {
   PyObject *v=NULL, *pyclassdoc=NULL, *open=NULL, *pyopendoc=NULL;
   PyObject *class = (PyObject *)api->data;
-  PyObject *inspect=NULL, *getdoc=NULL;
   const char *classname, *classdoc=NULL, *opendoc=NULL;
   char *doc=NULL;
   Py_ssize_t n=0, clen=0, olen=0, i, newlines=0;
@@ -213,6 +212,7 @@ char *helper(const DLiteStoragePlugin *api)
       //
       // Aligns pre-Python 3.13 behaviour with new behaviour which was
       // implemented into CPython in: https://github.com/python/cpython/pull/106411
+      PyObject *inspect=NULL, *getdoc=NULL;
       if (!(inspect = PyImport_ImportModule("inspect")))
         FAILCODE(dliteAttributeError, "cannot import inspect module");
       if (!((getdoc = PyObject_GetAttrString(inspect, "getdoc")) && PyCallable_Check(getdoc)))


### PR DESCRIPTION
# Description
Updated to cppcheck 2.18.3 and fixed new memory warnings that it found.

The starting point for this PR is that CI fails at the moment due the installation of cppcheck on Windows is broken (a needed file is not included). See https://github.com/SINTEF/dlite/actions/runs/18153879308/job/52119189099?pr=1217#step:13:321

To address this the following was done:

* On Windows MSVC, disable static-code-analysis (don't know how to fix it) 
* On Windows mingw, install cppcheck with pacman. This brings in version 2.18.3 of cppcheck that reviled a set of new memory warnings
* Fixed the memory warnings
* cppcheck 2.18.3 prints out a lot of information-level output makes it fail. Unfortunately the --disable=information option is not enough to turn off this output. But adding the option --check-level=exhaustive fixes it.

Unrelated additional fix:
* Improved instructions for how to set up postgresql service.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
