### PR TITLE
table w datamodels with varying shape

### DIFF
--- a/bindings/python/table.py
+++ b/bindings/python/table.py
@@ -86,9 +86,9 @@ class DMTable():
                 d["uri"] = baseuri + d["uri"]
 
             # Parse property mappings
+            dims = {}
             for idict in property_idicts:
                 prop = {}
-                dims = {}
                 for k, i in idict.items():
                     value = row[i] if row[i] else ""
                     if k == "shape" and value.strip():
@@ -102,8 +102,8 @@ class DMTable():
                         d["properties"].append(prop)
                     else:
                         d["properties"] = [prop]
-                if dims:
-                    d["dimensions"] = dims
+            if dims:
+                d["dimensions"] = dims
 
             self.datamodels[d["uri"]] = d
 

--- a/bindings/python/tests/input/datamodels2.csv
+++ b/bindings/python/tests/input/datamodels2.csv
@@ -1,2 +1,2 @@
 @id,description,title,datumName,datumType,datumUnit,datumShape,datumName[x],datumType[x],datumShape[x]
-http://onto-ns.com/meta/test/0.1/m1,"First data model.","Datamodel 1",length,float64,cm,"N, M",indices,int,"N"
+http://onto-ns.com/meta/test/0.1/m51,"First data model.","Datamodel 5.1",length,float64,cm,"N, M",indices,int,"N"

--- a/bindings/python/tests/input/datamodels2.csv
+++ b/bindings/python/tests/input/datamodels2.csv
@@ -1,0 +1,2 @@
+@id,description,title,datumName,datumType,datumUnit,datumShape,datumName[x],datumType[x],datumShape[x]
+http://onto-ns.com/meta/test/0.1/m1,"First data model.","Datamodel 1",length,float64,cm,"N, M",indices,int,"N"

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -62,9 +62,14 @@ assert m41.getprop("length").unit == "cm"
 
 # Test loading another csv file
 t5 = DMTable.from_csv(indir / "datamodels2.csv")
+# Line to be added in csv
+# http://onto-ns.com/meta/test/0.1/m52,"Antother data model.","Datamodel 5.2",length,float64,cm,,indices,int,
+#m51, m52 = t5.get_datamodels()
 m51, = t5.get_datamodels()
 assert isinstance(m51, dlite.Metadata)
 assert m51.description == "First data model."
+assert m51.ndimensions == 2 
+assert m51.nproperties == 2
 assert m51.getprop("length").type == "float64"
 assert m51.getprop("length").unit == "cm"
 assert m51.getprop("length").shape.tolist() == ["N", "M"]

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -18,44 +18,58 @@ table = [
     ("dm1",        "dm1",   "...",         "mass",         "float64",      "symbol",       "string",       "len,nsymbols"),
     ("dm2",        "dm2",   "...",         "name",         "string",       None,             "",           ""),
 ]
-t = DMTable(table, baseuri="http://onto-ns.com/meta/test/0.1/")
-dm1, dm2 = t.get_datamodels()
-assert isinstance(dm1, dlite.Metadata)
-assert isinstance(dm2, dlite.Metadata)
-assert dm1.getprop("symbol").name == "symbol"
-assert dm1.getprop("symbol").type == "string"
-assert dm1.getprop("symbol").shape.tolist() == ["len", "nsymbols"]
+t1 = DMTable(table, baseuri="http://onto-ns.com/meta/test/0.1/")
+dm11, dm12 = t1.get_datamodels()
+assert isinstance(dm11, dlite.Metadata)
+assert isinstance(dm12, dlite.Metadata)
+assert dm11.getprop("symbol").name == "symbol"
+assert dm11.getprop("symbol").type == "string"
+assert dm11.getprop("symbol").shape.tolist() == ["len", "nsymbols"]
 
 # Test loading csv file
 t2 = DMTable.from_csv(indir / "datamodels.csv")
-m1, m2 = t2.get_datamodels()
-assert isinstance(m1, dlite.Metadata)
-assert isinstance(m2, dlite.Metadata)
-assert m1.description == "First data model."
-assert m1.getprop("length").type == "float64"
-assert m1.getprop("length").unit == "cm"
-assert m2.getprop("key").type == "string"
-assert m2.getprop("indices").type == "int64"
-assert m2.getprop("indices").shape.tolist() == ["N", "M"]
+m21, m22 = t2.get_datamodels()
+assert isinstance(m21, dlite.Metadata)
+assert isinstance(m22, dlite.Metadata)
+assert m21.description == "First data model."
+assert m21.getprop("length").type == "float64"
+assert m21.getprop("length").unit == "cm"
+assert m22.getprop("key").type == "string"
+assert m22.getprop("indices").type == "int64"
+assert m22.getprop("indices").shape.tolist() == ["N", "M"]
 
 # Test loading excel file
 t3 = DMTable.from_excel(indir / "datamodels.xlsx")
-m3, m4 = t3.get_datamodels()
-assert isinstance(m3, dlite.Metadata)
-assert isinstance(m4, dlite.Metadata)
-assert m3.description == "First data model."
-assert m3.getprop("length").type == "float64"
-assert m3.getprop("length").unit == "cm"
-assert m4.getprop("key").type == "string"
-assert m4.getprop("indices").type == "int64"
-assert m4.getprop("indices").shape.tolist() == ["N", "M"]
+m33, m34 = t3.get_datamodels()
+assert isinstance(m33, dlite.Metadata)
+assert isinstance(m34, dlite.Metadata)
+assert m33.description == "First data model."
+assert m33.getprop("length").type == "float64"
+assert m33.getprop("length").unit == "cm"
+assert m34.getprop("key").type == "string"
+assert m34.getprop("indices").type == "int64"
+assert m34.getprop("indices").shape.tolist() == ["N", "M"]
 
 # Test loading given sheet and cellrange from excel
 t4 = DMTable.from_excel(
     indir / "datamodels.xlsx", sheet="sheet1", cellrange="A1:G2"
 )
-m5, = t4.get_datamodels()
-assert isinstance(m5, dlite.Metadata)
-assert m5.description == "First data model."
-assert m5.getprop("length").type == "float64"
-assert m5.getprop("length").unit == "cm"
+m41, = t4.get_datamodels()
+assert isinstance(m41, dlite.Metadata)
+assert m41.description == "First data model."
+assert m41.getprop("length").type == "float64"
+assert m41.getprop("length").unit == "cm"
+
+# Test loading another csv file
+t5 = DMTable.from_csv(indir / "datamodels2.csv")
+m51, = t5.get_datamodels()
+assert isinstance(m41, dlite.Metadata)
+assert m51.description == "First data model."
+assert m51.getprop("length").type == "float64"
+assert m51.getprop("length").unit == "cm"
+assert m51.getprop("length").shape.tolist() == ["N", "M"]
+assert m51.getprop("indices").type == "int64"
+assert m51.getprop("indices").shape.tolist() == ["N"]
+
+
+

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -63,7 +63,7 @@ assert m41.getprop("length").unit == "cm"
 # Test loading another csv file
 t5 = DMTable.from_csv(indir / "datamodels2.csv")
 m51, = t5.get_datamodels()
-assert isinstance(m41, dlite.Metadata)
+assert isinstance(m51, dlite.Metadata)
 assert m51.description == "First data model."
 assert m51.getprop("length").type == "float64"
 assert m51.getprop("length").unit == "cm"


### PR DESCRIPTION
# Description
Tables with datamodels with properties with varying shape are not parsed correctly. 
They look correct when printeed with dmtable.datamodels, but when you actually retreieve the datamodels with dmtable.get_datamodels it just gives an incomplete datamodel.

## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
