### PR TITLE
Emptyshape invaliddict

### DIFF
--- a/bindings/python/table.py
+++ b/bindings/python/table.py
@@ -62,7 +62,7 @@ class DMTable():
                 "http://example.com/data/0.1/blah".
 
         """
-        self.datamodels = {}  # Maps uri to datamodel dict
+        self.dmdicts = {}  # Maps uri to datamodel dict
         self.datamodel_mappings = datamodel_mappings
         self.property_mappings = property_mappings
 
@@ -92,10 +92,12 @@ class DMTable():
                 prop = {}
                 for k, i in idict.items():
                     value = row[i] if row[i] else ""
-                    if k == "shape" and value.strip():
-                        prop[k] = [s.strip() for s in value.strip("[]").split(",")]
-                        for dim in prop[k]:
-                            dims[dim] = f"{dim} dimension"
+
+                    if k == "shape":
+                        if value.strip():
+                            prop[k] = [s.strip() for s in value.strip("[]").split(",")]
+                            for dim in prop[k]:
+                                dims[dim] = f"{dim} dimension"
                     else:
                         prop[k] = value.strip()
                 if prop["name"]:
@@ -106,7 +108,7 @@ class DMTable():
             if dims:
                 d["dimensions"] = dims
 
-            self.datamodels[d["uri"]] = d
+            self.dmdicts[d["uri"]] = d
 
     def _get_datamodel_idict(self, header: "Sequence[str]") -> "dict":
         """Help function that returns a dict mapping datamodel fields to
@@ -147,7 +149,7 @@ class DMTable():
 
     def get_datamodels(self) -> "list[dlite.Metadata]":
         """Return a list with all datamodels parsed from the table."""
-        return [dlite.Metadata.from_dict(d) for d in self.datamodels.values()]
+        return [dlite.Metadata.from_dict(d) for d in self.dmdicts.values()]
 
     @staticmethod
     def from_csv(

--- a/bindings/python/table.py
+++ b/bindings/python/table.py
@@ -95,7 +95,10 @@ class DMTable():
 
                     if k == "shape":
                         if value.strip():
-                            prop[k] = [s.strip() for s in value.strip("[]").split(",")]
+                            prop[k] = [
+                                s.strip()
+                                for s in value.strip().strip("[]").split(",")
+                            ]
                             for dim in prop[k]:
                                 dims[dim] = f"{dim} dimension"
                     else:

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -16,11 +16,12 @@ import test_storage
 # Test loading a python table
 table = [
     ("@id", "label", "description", "datumName[1]", "datumType[1]", "datumName[2]", "datumType[2]", "datumShape[2]"),
-    ("dm1",        "dm1",   "...",         "mass",         "float64",      "symbol",       "string",       "len,nsymbols"),
-    ("dm2",        "dm2",   "...",         "name",         "string",       None,             "",           ""),
+    ("dm1", "dm1",   "...",         "mass",         "float64",      "symbol",       "string",       "len,nsymbols"),
+    ("dm2", "dm2",   "...",         "name",         "string",       None,            "",            ""),
+    ("dm3", "dm3",   "...",         "length",       "float",        "scalar",        "float64",     ""),
 ]
 t1 = DMTable(table, baseuri="http://onto-ns.com/meta/test/0.1/")
-dm11, dm12 = t1.get_datamodels()
+dm11, dm12, dm13 = t1.get_datamodels()
 assert isinstance(dm11, dlite.Metadata)
 assert isinstance(dm12, dlite.Metadata)
 assert dm11.getprop("symbol").name == "symbol"

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -23,10 +23,23 @@ table = [
 t1 = DMTable(table, baseuri="http://onto-ns.com/meta/test/0.1/")
 dm11, dm12, dm13 = t1.get_datamodels()
 assert isinstance(dm11, dlite.Metadata)
-assert isinstance(dm12, dlite.Metadata)
+assert dm11.ndimensions == 2
+assert dm11.nproperties == 2
 assert dm11.getprop("symbol").name == "symbol"
 assert dm11.getprop("symbol").type == "string"
 assert dm11.getprop("symbol").shape.tolist() == ["len", "nsymbols"]
+
+assert isinstance(dm12, dlite.Metadata)
+assert dm12.ndimensions == 0
+assert dm12.nproperties == 1
+assert dm12.getprop("name").type == "string"
+
+assert isinstance(dm13, dlite.Metadata)
+assert dm13.ndimensions == 0
+assert dm13.nproperties == 2
+assert dm13.getprop("scalar").type == "float64"
+assert dm13.getprop("scalar").shape.tolist() == []
+
 
 # Test loading csv file
 t2 = DMTable.from_csv(indir / "datamodels.csv")

--- a/bindings/python/tests/test_utils.py
+++ b/bindings/python/tests/test_utils.py
@@ -201,3 +201,55 @@ ds.add({
     "dimensions": [0],
     "properties": {"relations": []},
 })
+
+
+
+dict_shape_emptystr = {
+    'uri': 'http://onto-ns.com/meta/test/0.1/m52',
+    'description': 'Antother data model.',
+    'properties': [
+        {
+            'name': 'length',
+            'type': 'float64',
+            'unit': 'cm',
+            'shape': ''
+        },{
+            'name': 'indices', 
+            'type': 'int', 
+            'shape': ''
+        },
+    ],
+}
+
+
+
+assert isinstance(
+
+
+
+dict_invaliddm = {
+    'http://onto-ns.com/meta/test/0.1/invalid1': {
+        'uri': 'http://onto-ns.com/meta/test/0.1/invalid1',
+        'description': 'Invalid data model.',
+        'properties': [
+            {
+                'name': 'length',
+                'type': 'float64',
+                'unit': 'cm',
+                'shape': ''
+            },{
+                'name': 'indices', 
+                'type': 'intu', #invalid unit type 
+                'shape': ''
+            },
+        ],
+    },
+}
+
+assert correct exception
+assert no instance with uri 'http://onto-ns.com/meta/test/0.1/invalid1'
+
+
+
+
+

--- a/bindings/python/tests/test_utils.py
+++ b/bindings/python/tests/test_utils.py
@@ -12,6 +12,7 @@ from dlite.utils import (
     HAVE_DATACLASSES,
     HAVE_PYDANTIC,
 )
+from dlite.testutils import raises
 
 
 thisdir = Path(__file__).absolute().parent
@@ -67,7 +68,7 @@ d = {
 }
 
 inst = instance_from_dict(d)
-print(inst)
+#print(inst)
 
 
 Person = dlite.Instance.from_url(f"json://{entitydir}/Person.json")
@@ -81,6 +82,44 @@ inst1 = instance_from_dict(d1)
 
 d2 = Person.asdict()
 inst2 = instance_from_dict(d2)
+
+
+# Shape must be a sequence of strings
+dict_badshape = {
+    'uri': 'http://onto-ns.com/meta/test/0.1/badshape',
+    'description': 'Antother data model.',
+    'properties': [
+        {
+            'name': 'length',
+            'type': 'float64',
+            'unit': 'cm',
+            'shape': "",
+        },
+    ],
+}
+with raises(dlite.DLiteParseError, dlite.DLiteIOError):
+    inst3 = instance_from_dict(dict_badshape)
+
+# No instance should be created on error
+assert not dlite.has_instance("http://onto-ns.com/meta/test/0.1/badshape")
+
+# Instance should not be created on error
+dict_invalidtype = {
+    'http://onto-ns.com/meta/test/0.1/invalid1': {
+        'uri': 'http://onto-ns.com/meta/test/0.1/invalid1',
+        'description': 'Invalid data model.',
+        'properties': [
+            {
+                'name': 'indices',
+                'type': 'intu', #invalid unit type
+                'shape': ''
+            },
+        ],
+    },
+}
+with raises(dlite.DLiteIOError, dlite.DLiteTypeError):
+    inst4 = instance_from_dict(dict_invalidtype)
+assert not dlite.has_instance("http://onto-ns.com/meta/test/0.1/invalid1")
 
 
 if HAVE_DATACLASSES:
@@ -201,55 +240,3 @@ ds.add({
     "dimensions": [0],
     "properties": {"relations": []},
 })
-
-
-
-dict_shape_emptystr = {
-    'uri': 'http://onto-ns.com/meta/test/0.1/m52',
-    'description': 'Antother data model.',
-    'properties': [
-        {
-            'name': 'length',
-            'type': 'float64',
-            'unit': 'cm',
-            'shape': ''
-        },{
-            'name': 'indices', 
-            'type': 'int', 
-            'shape': ''
-        },
-    ],
-}
-
-
-
-assert isinstance(
-
-
-
-dict_invaliddm = {
-    'http://onto-ns.com/meta/test/0.1/invalid1': {
-        'uri': 'http://onto-ns.com/meta/test/0.1/invalid1',
-        'description': 'Invalid data model.',
-        'properties': [
-            {
-                'name': 'length',
-                'type': 'float64',
-                'unit': 'cm',
-                'shape': ''
-            },{
-                'name': 'indices', 
-                'type': 'intu', #invalid unit type 
-                'shape': ''
-            },
-        ],
-    },
-}
-
-assert correct exception
-assert no instance with uri 'http://onto-ns.com/meta/test/0.1/invalid1'
-
-
-
-
-

--- a/src/dlite-json.c
+++ b/src/dlite-json.c
@@ -751,7 +751,9 @@ static DLiteInstance *parse_instance(const char *src, jsmntok_t *obj,
   if (uri) free(uri);
   if (metauri) free(metauri);
   if (!ok && inst) {
-    dlite_instance_decref(inst);
+    /* Metadata has an extra refcount, so loop until refcount is zero */
+    while (inst->_refcount)
+      dlite_instance_decref(inst);
     inst = NULL;
   }
   if (meta) dlite_meta_decref((DLiteMeta *)meta);


### PR DESCRIPTION
# Description
Changes:
- If creating a datamodel from json fails, make sure that no half-populated datamodel instance will remain.
- Support shape specified as an empty string in a table.
- Renamed the `DMTable.datamodels` attribute to `DMTable.dmdicts`.
- Added tests for the two first bullet points.


## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
