### PR TITLE
Ignore confusing openpyxl warning

### DIFF
--- a/bindings/python/table.py
+++ b/bindings/python/table.py
@@ -1,6 +1,7 @@
 """Utilities for reading and writing DLite instances from and to tables."""
 import csv
 import re
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -255,14 +256,23 @@ class DMTable():
         """
         from openpyxl import load_workbook
 
-        wb = load_workbook(
-            excelfile,
-            read_only=True,
-            keep_vba=False,
-            data_only=True,
-            keep_links=False,
-            rich_text=False,
-        )
+        # load_workbook() warns about missing default style, but
+        # doesn't provide a way to specify it. Ignore the warning!
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                module=re.escape('openpyxl.styles.stylesheet')
+            )
+            wb = load_workbook(
+                excelfile,
+                read_only=True,
+                keep_vba=False,
+                data_only=True,
+                keep_links=False,
+                rich_text=False,
+            )
+
         # Get worksheet
         ws = wb[wb.sheetnames[sheet] if isinstance(sheet, int) else sheet]
 


### PR DESCRIPTION
# Description
Openpyxl issues the "Workbook contains no default style, apply openpyxl's default", but does not offer an easy way to specify a default style. 

Follow the [stack overflow](https://stackoverflow.com/questions/66214951/deal-with-openpyxl-warning-workbook-contains-no-default-style-apply-openpyxl) solution and ignore it.


## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
