### PR TITLE
Save datamodel table to triplestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPi](https://img.shields.io/pypi/v/dlite-python.svg)](https://pypi.org/project/dlite-python/)
 [![CI tests](https://github.com/sintef/dlite/workflows/CI%20tests/badge.svg)](https://github.com/SINTEF/dlite/actions)
 [![Documentation](https://img.shields.io/badge/documentation-informational?logo=githubpages)](https://sintef.github.io/dlite/index.html)
-[![DOI](https://doi.org/10.5281/zenodo.207571283%2Fzenodo-blue.svg)](https://zenodo.org/badge/latestdoi/207571283)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7811078.svg)](https://doi.org/10.5281/zenodo.7811078)
 <!--
 [![DOI](https://zenodo.org/badge/207571283.svg)](https://zenodo.org/badge/latestdoi/207571283)
 -->

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![PyPi](https://img.shields.io/pypi/v/dlite-python.svg)](https://pypi.org/project/dlite-python/)
 [![CI tests](https://github.com/sintef/dlite/workflows/CI%20tests/badge.svg)](https://github.com/SINTEF/dlite/actions)
 [![Documentation](https://img.shields.io/badge/documentation-informational?logo=githubpages)](https://sintef.github.io/dlite/index.html)
+[![DOI](https://doi.org/10.5281/zenodo.207571283%2Fzenodo-blue.svg)](https://zenodo.org/badge/latestdoi/207571283)
+<!--
 [![DOI](https://zenodo.org/badge/207571283.svg)](https://zenodo.org/badge/latestdoi/207571283)
+-->
 
 > A lightweight data-centric framework for semantic interoperability
 

--- a/bindings/python/dataset.py
+++ b/bindings/python/dataset.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from tripper import Literal, Namespace, Triplestore
 from tripper import MAP, OTEIO, OWL, RDF, RDFS, SKOS, XSD
-from tripper.utils import en
+from tripper.utils import en, expand_iri
 from tripper.errors import NoSuchIRIError
 
 import dlite
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # XXX TODO - Make a local cache of EMMO such that we only download it once
 TS_EMMO = Triplestore("rdflib")
-TS_EMMO.parse("https://w3id.org/emmo/1.0.0")
+TS_EMMO.parse("https://w3id.org/emmo/1.0.4")
 
 EMMO_VERSIONIRI = TS_EMMO.value("https://w3id.org/emmo", OWL.versionIRI)
 
@@ -227,16 +227,30 @@ def metadata_to_rdf(
     # Create lookup table
     dct = meta.asdict()
 
+    prefixes = {
+        "map": MAP,
+        "oteio": OTEIO,
+        "owl": OWL,
+        "rdf": RDF,
+        "rdfs": RDFS,
+        "skos": SKOS,
+        "xsd": XSD,
+        "emmo": EMMO,
+    }
+
     # For adding mappings
     maps = defaultdict(list)
     for s, p, o in mappings:
+        s = expand_iri(s, prefixes=prefixes)
+        p = expand_iri(p, prefixes=prefixes)
+        o = expand_iri(o, prefixes=prefixes)
         uri = str(s).rstrip("/#")
         if p == MAP.mapsTo:
             name = str(s).split("#", 1)[-1]
-            prep = RDF.type if name in meta.dimnames() else RDFS.subClassOf
+            pred = RDF.type if name in meta.dimnames() else RDFS.subClassOf
         else:
-            prep = p
-        maps[uri].append((prep, o))
+            pred = p
+        maps[uri].append((pred, o))
 
     def addmap(uri, iri):
         """Add mapping relation to triples."""

--- a/bindings/python/dataset.py
+++ b/bindings/python/dataset.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # XXX TODO - Make a local cache of EMMO such that we only download it once
 TS_EMMO = Triplestore("rdflib")
-TS_EMMO.parse("https://w3id.org/emmo/1.0.3")
+TS_EMMO.parse("https://w3id.org/emmo/1.0.0")
 #TS_EMMO.parse("https://w3id.org/emmo/1.0.4/disciplines/units/unit-individuals")
 #TS_EMMO.parse("https://w3id.org/emmo/unit-individuals")
 
@@ -243,9 +243,9 @@ def metadata_to_rdf(
     # For adding mappings
     maps = defaultdict(list)
     for s, p, o in mappings:
-        s = expand_iri(s, prefixes=prefixes)
-        p = expand_iri(p, prefixes=prefixes)
-        o = expand_iri(o, prefixes=prefixes)
+        s = expand_iri(str(s), prefixes=prefixes)
+        p = expand_iri(str(p), prefixes=prefixes)
+        o = expand_iri(str(o), prefixes=prefixes)
         uri = str(s).rstrip("/#")
         if p == MAP.mapsTo:
             name = str(s).split("#", 1)[-1]

--- a/bindings/python/dataset.py
+++ b/bindings/python/dataset.py
@@ -27,7 +27,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # XXX TODO - Make a local cache of EMMO such that we only download it once
 TS_EMMO = Triplestore("rdflib")
-TS_EMMO.parse("https://w3id.org/emmo/1.0.4")
+TS_EMMO.parse("https://w3id.org/emmo/1.0.3")
+#TS_EMMO.parse("https://w3id.org/emmo/1.0.4/disciplines/units/unit-individuals")
+#TS_EMMO.parse("https://w3id.org/emmo/unit-individuals")
 
 EMMO_VERSIONIRI = TS_EMMO.value("https://w3id.org/emmo", OWL.versionIRI)
 

--- a/bindings/python/table.py
+++ b/bindings/python/table.py
@@ -24,6 +24,7 @@ DEFAULT_PROPERTY_MAPPINGS = {
     "unit": "datumUnit",
     "shape": "datumShape",
     "description": "datumDescription",
+    "mapping": "datumMapping",
 }
 
 
@@ -90,14 +91,18 @@ class DMTable():
             for idict in property_idicts:
                 prop = {}
                 for k, i in idict.items():
-                    value = row[i] if row[i] else ""
-                    if k == "shape" and value.strip():
-                        prop[k] = [s.strip() for s in value.strip("[]").split(",")]
-                        for dim in prop[k]:
-                            dims[dim] = f"{dim} dimension"
-                    else:
-                        prop[k] = value.strip()
-                if prop["name"]:
+                    value = row[i].strip() if row[i] else ""
+
+                    if k == "shape" and value:
+                            prop[k] = [
+                                s.strip()
+                                for s in value.strip("[]").split(",")
+                            ]
+                            for dim in prop[k]:
+                                dims[dim] = f"{dim} dimension"
+                    elif value:
+                        prop[k] = value
+                if prop.get("name"):
                     if "properties" in d:
                         d["properties"].append(prop)
                     else:
@@ -284,8 +289,23 @@ class DMTable():
             baseuri=baseuri,
         )
 
+    def to_triplestore(self, ts: "Triplestore"):
+        """Save all datamodels to Tripper triplestore `ts`."""
 
-def csvsniff(sample):
+        # Import here since since dlite.dataset depends on tripper
+        from dlite.dataset import add_dataset
+
+        for uri, d in self.dmdicts.items():
+            meta = dlite.Metadata.from_dict(d)
+            mappings = []
+            for props in d["properties"]:
+                if "mapping" in props:
+                    iri = f"{uri}#{props['name']}"
+                    mappings.append((iri, "rdfs:subClassOf", props["mapping"]))
+            add_dataset(ts, meta, iri=uri, mappings=mappings)
+
+
+def csvsniff(sample: str) -> "csv.Dialect":
     """Custom csv sniffer.
 
     Analyse csv sample and returns a csv.Dialect instance.

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -1,4 +1,5 @@
 """Test dlite.table.DMTable"""
+import warnings
 from pathlib import Path
 
 import dlite
@@ -38,43 +39,66 @@ assert m22.getprop("key").type == "string"
 assert m22.getprop("indices").type == "int64"
 assert m22.getprop("indices").shape.tolist() == ["N", "M"]
 
-# Test loading excel file
-t3 = DMTable.from_excel(indir / "datamodels.xlsx")
-m33, m34 = t3.get_datamodels()
-assert isinstance(m33, dlite.Metadata)
-assert isinstance(m34, dlite.Metadata)
-assert m33.description == "First data model."
-assert m33.getprop("length").type == "float64"
-assert m33.getprop("length").unit == "cm"
-assert m34.getprop("key").type == "string"
-assert m34.getprop("indices").type == "int64"
-assert m34.getprop("indices").shape.tolist() == ["N", "M"]
-
-# Test loading given sheet and cellrange from excel
-t4 = DMTable.from_excel(
-    indir / "datamodels.xlsx", sheet="sheet1", cellrange="A1:G2"
-)
-m41, = t4.get_datamodels()
-assert isinstance(m41, dlite.Metadata)
-assert m41.description == "First data model."
-assert m41.getprop("length").type == "float64"
-assert m41.getprop("length").unit == "cm"
 
 # Test loading another csv file
-t5 = DMTable.from_csv(indir / "datamodels2.csv")
+t3 = DMTable.from_csv(indir / "datamodels2.csv")
 # Line to be added in csv
-# http://onto-ns.com/meta/test/0.1/m52,"Antother data model.","Datamodel 5.2",length,float64,cm,,indices,int,
-#m51, m52 = t5.get_datamodels()
-m51, = t5.get_datamodels()
-assert isinstance(m51, dlite.Metadata)
-assert m51.description == "First data model."
-assert m51.ndimensions == 2 
-assert m51.nproperties == 2
-assert m51.getprop("length").type == "float64"
-assert m51.getprop("length").unit == "cm"
-assert m51.getprop("length").shape.tolist() == ["N", "M"]
-assert m51.getprop("indices").type == "int64"
-assert m51.getprop("indices").shape.tolist() == ["N"]
+# http://onto-ns.com/meta/test/0.1/m32,"Antother data model.","Datamodel 5.2",length,float64,cm,,indices,int,
+#m31, m32 = t5.get_datamodels()
+m31, = t3.get_datamodels()
+assert isinstance(m31, dlite.Metadata)
+assert m31.description == "First data model."
+assert m31.ndimensions == 2
+assert m31.nproperties == 2
+assert m31.getprop("length").type == "float64"
+assert m31.getprop("length").unit == "cm"
+assert m31.getprop("length").shape.tolist() == ["N", "M"]
+assert m31.getprop("indices").type == "int64"
+assert m31.getprop("indices").shape.tolist() == ["N"]
 
 
+# Test loading excel file
+if importcheck("openpyxl"):
+    t4 = DMTable.from_excel(indir / "datamodels.xlsx")
+    m43, m44 = t4.get_datamodels()
+    assert isinstance(m43, dlite.Metadata)
+    assert isinstance(m44, dlite.Metadata)
+    assert m43.description == "First data model."
+    assert m43.getprop("length").type == "float64"
+    assert m43.getprop("length").unit == "cm"
+    assert m44.getprop("key").type == "string"
+    assert m44.getprop("indices").type == "int64"
+    assert m44.getprop("indices").shape.tolist() == ["N", "M"]
 
+    # Test loading given sheet and cellrange from excel
+    t5 = DMTable.from_excel(
+        indir / "datamodels.xlsx", sheet="sheet1", cellrange="A1:G2"
+    )
+    m51, = t5.get_datamodels()
+    assert isinstance(m51, dlite.Metadata)
+    assert m51.description == "First data model."
+    assert m51.getprop("length").type == "float64"
+    assert m51.getprop("length").unit == "cm"
+
+
+# Test saving to triplestore (slow...)
+if importcheck("tripper") and importcheck("rdflib"):
+    from tripper import Triplestore, EMMO, OWL, RDF, RDFS, SKOS
+    from tripper.utils import en
+
+    ts = Triplestore("rdflib")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "more than one unit with symbol.*", UserWarning)
+        t2.to_triplestore(ts)
+
+    #print(ts.serialize())
+    m1 = "http://onto-ns.com/meta/test/0.1/m1"
+    assert ts.has(m1, RDF.type, OWL.Class)
+    assert ts.has(m1, RDFS.subClassOf, EMMO.Dataset)
+    assert ts.has(m1, SKOS.prefLabel, en("M1"))
+
+    length = "http://onto-ns.com/meta/test/0.1/m1#length"
+    assert ts.has(length, RDF.type, OWL.Class)
+    assert ts.has(length, RDFS.subClassOf, EMMO.Datum)
+    assert ts.has(length, RDFS.subClassOf, EMMO.DoubleData)
+    assert ts.has(length, SKOS.prefLabel, en("Length"))

--- a/doc/user_guide/datamodels.md
+++ b/doc/user_guide/datamodels.md
@@ -112,20 +112,21 @@ Note that `dimensions` is inferred from the shapes of the properties.
 
 ```python
 # Default mappings of DLite metadata fields to table header names
-DEFAULT_DATAMODEL_MAPPINGS = {
-    "uri": "@id",
-    "dimensions": None,
-    "description": "description",
-}
+>>> DEFAULT_DATAMODEL_MAPPINGS = {
+...     "uri": "@id",
+...     "dimensions": None,
+...     "description": "description",
+... }
 # Default mappings of DLite property fields to table header names
-DEFAULT_PROPERTY_MAPPINGS = {
-    "name": "datumName",
-    "type": "datumType",
-    "ref": "datumRef",
-    "unit": "datumUnit",
-    "shape": "datumShape",
-    "description": "datumDescription",
-}
+>>> DEFAULT_PROPERTY_MAPPINGS = {
+...     "name": "datumName",
+...     "type": "datumType",
+...     "ref": "datumRef",
+...     "unit": "datumUnit",
+...     "shape": "datumShape",
+...     "description": "datumDescription",
+... }
+
 ```
 
 > [!NOTE]
@@ -136,10 +137,10 @@ Assuming that the above table is stored in a CSV file called `datamodels.csv`.
 Python objects `m1` and `m2` for these datamodels can then be created with the following code
 
 ```python
-from dlite.table import DMTable
+>>> from dlite.table import DMTable
+>>> t2 = DMTable.from_csv(indir / "datamodels.csv")
+>>> m1, m2 = t2.get_datamodels()
 
-t2 = DMTable.from_csv(indir / "datamodels.csv")
-m1, m2 = t2.get_datamodels()
 ```
 
 The optional `datamodel_mappings` and `property_mappings` arguments of `DMTable.from_csv()` allow the user to provide custom mappings for the datamodel (`uri`, `description`) and property (`name`, `type`, `ref`, `unit`, `shape`, `description`) fields.
@@ -156,12 +157,28 @@ The above table could then be rewritten as follows:
 and the python code to create the same datamodels as above would be:
 
 ```python
-from dlite.table import DMTable
-t2 = DMTable.from_csv(indir / "datamodels.csv", baseuri="http://onto-ns.com/meta/test/0.1")
-m1, m2 = t2.get_datamodels()
+>>> from dlite.table import DMTable
+>>> t2 = DMTable.from_csv(indir / "datamodels.csv", baseuri="http://onto-ns.com/meta/test/0.1")
+>>> m1, m2 = t2.get_datamodels()
+
 ```
 
 Note that if the baseuri is not given and the `uri` is not a true IRI, an error will be raised.
+
+
+### Storing the datamodels to a triplestore
+Continuing with example above, the DMTable class has a `to_triplestore()` method that can be used to store the datamodels to a triplestore using the [tripper] package.
+
+For example will the following
+
+```python
+>>> from tripper import Triplestore
+>>> ts = Triplestore("rdflib")
+>>> t2.to_triplestore(ts)
+
+```
+
+store all the datamodels in `t2` to the triplestore, representing them as proper EMMO datasets.
 
 
 
@@ -205,3 +222,4 @@ The [dlite-validate] tool can be used to check if a specific representation (in 
 [JSON]: https://www.json.org/
 [YAML]: https://yaml.org/
 [dlite-validate]: https://sintef.github.io/dlite/user_guide/tools.html#dlite-validate
+[tripper]: https://emmc-asbl.github.io/tripper/

--- a/examples/dataset/README.md
+++ b/examples/dataset/README.md
@@ -6,7 +6,7 @@ and instances to and from an EMMO-based RDF representation.
 
 ![EMMO-based representation of a datamodel.](https://raw.githubusercontent.com/SINTEF/dlite/652-serialise-data-models-to-tbox/doc/_static/dataset-v2.svg)
 
-The figure above shown how the following simple [`FluidData`]
+The figure above show how the following simple [`FluidData`]
 datamodel is represented with EMMO.
 
 ```yaml


### PR DESCRIPTION
# Description
Added method `to_triplestore()` to `table.DMTable`.

This method makes it easy to save all datamodels to a tripper Triplestore object.

## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
