### PR TITLE
Normalise unicode characters used in units before matching

### DIFF
--- a/bindings/python/dataset.py
+++ b/bindings/python/dataset.py
@@ -6,6 +6,7 @@ NOTE: This module depends on Tripper.
 """
 import json
 import re
+import unicodedata
 import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING
@@ -195,6 +196,9 @@ def get_unit_iri(unit):
     """Returns the IRI for the given unit."""
     if is_valid_url(unit):
         return unit
+
+    # Convert unicodes that prints identical to standard form
+    unit = unicodedata.normalize("NFC", unit).replace("\u22c5", "\u00b7")
 
     if not unit_cache:
         ts = TS_EMMO

--- a/bindings/python/tests/test_dataset1_save.py
+++ b/bindings/python/tests/test_dataset1_save.py
@@ -27,6 +27,9 @@ from dlite.dataset import MissingUnitError, get_unit_iri
 assert get_unit_iri("Kelvin") == "https://w3id.org/emmo#Kelvin"
 assert get_unit_iri("K") == "https://w3id.org/emmo#Kelvin"
 assert get_unit_iri("°C") == "https://w3id.org/emmo#DegreeCelsius"
+assert get_unit_iri("g·mm") == "https://w3id.org/emmo#GramMilliMetre"
+# Alternative unicode (\u22c5 instead of \u00b7)
+assert get_unit_iri("g⋅mm") == "https://w3id.org/emmo#GramMilliMetre"
 assert get_unit_iri("m/s") == "https://w3id.org/emmo#MetrePerSecond"
 
 with raises(MissingUnitError):
@@ -36,6 +39,7 @@ with raises(MissingUnitError):
     # Ångström is not included in EMMO by default. It can be including by
     # importing https://w3id.org/emmo/1.0.0-rc1/disciplines/units/specialunits
     get_unit_iri("Å")
+
 
 
 # To be fixed in issue https://github.com/SINTEF/dlite/issues/878


### PR DESCRIPTION
# Description
Normalise unicode characters that print identical units before searching for matching labels in get_unit_iri().

## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
