### PR TITLE
Remove API that may lead to segfault

### DIFF
--- a/bindings/python/dlite-storage-python.i
+++ b/bindings/python/dlite-storage-python.i
@@ -49,11 +49,6 @@
           _dlite._load_all_storage_plugins()
 
       @classmethod
-      def unload_plugin(cls, name):
-          """Unload storage plugin with this name."""
-          _dlite._unload_storage_plugin(str(name))
-
-      @classmethod
       def plugin_help(cls, name):
           """Return documentation of storage plogin with this name."""
           return _dlite._storage_plugin_help(name)

--- a/bindings/python/dlite-storage.i
+++ b/bindings/python/dlite-storage.i
@@ -235,9 +235,6 @@ Iterates over loaded storage plugins.
 %rename(_load_all_storage_plugins) dlite_storage_plugin_load_all;
 int dlite_storage_plugin_load_all();
 
-%rename(_unload_storage_plugin) dlite_storage_plugin_unload;
-int dlite_storage_plugin_unload(const char *name);
-
 char *_storage_plugin_help(const char *name);
 
 

--- a/bindings/python/tests/test_python_bindings.py
+++ b/bindings/python/tests/test_python_bindings.py
@@ -52,7 +52,6 @@ def test(verbosity=1, stream=sys.stdout):
         # Exclude test_global_dlite_state.py since the global state
         # that it is testing depends on the other tests.
         and not test.endswith("test_global_dlite_state.py")
-        and not test.endswith("test_table.py")
     ]
     ts = unittest.TestSuite()
     for test in sorted(tests):

--- a/bindings/python/tests/test_storage_plugins.py
+++ b/bindings/python/tests/test_storage_plugins.py
@@ -44,13 +44,3 @@ print()
 print("Undocumented plugins")
 print("====================")
 print("  - " + "\n  - ".join(undoc))
-
-
-
-# Unload json plugin
-# FIXME: Creates a dangling pointer to ->apis on cached instances - at least on macOS
-# DLite `plugin_unload` needs to be reviewed regarding how this behavior should work.
-#import sys
-#if sys.platform != "darwin":
-#    dlite.Storage.unload_plugin("json")
-#    assert "json" not in set(dlite.StoragePluginIter())

--- a/bindings/python/tests/test_storage_plugins.py
+++ b/bindings/python/tests/test_storage_plugins.py
@@ -50,7 +50,7 @@ print("  - " + "\n  - ".join(undoc))
 # Unload json plugin
 # FIXME: Creates a dangling pointer to ->apis on cached instances - at least on macOS
 # DLite `plugin_unload` needs to be reviewed regarding how this behavior should work.
-import sys
-if sys.platform != "darwin":
-    dlite.Storage.unload_plugin("json")
-    assert "json" not in set(dlite.StoragePluginIter())
+#import sys
+#if sys.platform != "darwin":
+#    dlite.Storage.unload_plugin("json")
+#    assert "json" not in set(dlite.StoragePluginIter())

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -221,23 +221,6 @@ int dlite_storage_plugin_load_all()
 }
 
 /*
-  Unloads and unregisters all storage plugins.
-*/
-void dlite_storage_plugin_unload_all()
-{
-  PluginInfo *info;
-  char **p, **names;
-  dlite_storage_hotlist_clear();
-  if (!(info = get_storage_plugin_info())) return;
-  if (!(names = plugin_names(info))) return;
-  for (p=names; *p; p++) {
-    plugin_unload(info, *p);
-    free(*p);
-  }
-  free(names);
-}
-
-/*
   Returns a pointer to a new plugin iterator or NULL on error.  It
   should be free'ed with dlite_storage_plugin_iter_free().
  */
@@ -269,18 +252,6 @@ dlite_storage_plugin_iter_next(DLiteStoragePluginIter *iter)
 void dlite_storage_plugin_iter_free(DLiteStoragePluginIter *iter)
 {
   free(iter);
-}
-
-
-/*
-  Unloads and unregisters storage plugin with the given name.
-  Returns non-zero on error.
-*/
-int dlite_storage_plugin_unload(const char *name)
-{
-  PluginInfo *info;
-  if (!(info = get_storage_plugin_info())) return 1;
-  return plugin_unload(info, name);
 }
 
 

--- a/src/dlite-storage-plugins.c
+++ b/src/dlite-storage-plugins.c
@@ -227,6 +227,7 @@ void dlite_storage_plugin_unload_all()
 {
   PluginInfo *info;
   char **p, **names;
+  dlite_storage_hotlist_clear();
   if (!(info = get_storage_plugin_info())) return;
   if (!(names = plugin_names(info))) return;
   for (p=names; *p; p++) {

--- a/src/dlite-storage-plugins.h
+++ b/src/dlite-storage-plugins.h
@@ -130,11 +130,6 @@ const DLiteStoragePlugin *dlite_storage_plugin_get(const char *name);
 int dlite_storage_plugin_load_all();
 
 /**
-  Unloads and unregisters all storage plugins.
-*/
-void dlite_storage_plugin_unload_all();
-
-/**
   Returns a pointer to a new plugin iterator or NULL on error.  It
   should be free'ed with dlite_storage_plugin_iter_free().
  */
@@ -153,12 +148,6 @@ dlite_storage_plugin_iter_next(DLiteStoragePluginIter *iter);
  */
 void dlite_storage_plugin_iter_free(DLiteStoragePluginIter *iter);
 
-
-/**
-  Unloads and unregisters storage plugin with the given name.
-  Returns non-zero on error.
-*/
-int dlite_storage_plugin_unload(const char *name);
 
 /**
   Returns a pointer to the underlying FUPaths object for storage plugins

--- a/src/tests/python/test_python_mapping.c
+++ b/src/tests/python/test_python_mapping.c
@@ -59,7 +59,6 @@ MU_TEST(test_map)
 
   dlite_instance_decref(inst3);
   dlite_instance_decref(ent3);
-  //dlite_instance_decref((DLiteInstance *)instances[0]);
 }
 
 
@@ -73,7 +72,6 @@ MU_TEST(test_finalize)
 
 MU_TEST(test_plugin_unload_all)
 {
-  dlite_storage_plugin_unload_all();
   dlite_mapping_plugin_unload_all();
 }
 

--- a/src/tests/test_datamodel.c
+++ b/src/tests/test_datamodel.c
@@ -261,12 +261,6 @@ MU_TEST(test_has_property)
   mu_check(dlite_datamodel_has_property(d, "xxx") == 0);
 }
 
-MU_TEST(test_storage_plugin_unload_all)
-{
-  dlite_storage_plugin_unload_all();
-}
-
-
 
 /***********************************************************************/
 
@@ -295,8 +289,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_has_property);
 
   MU_RUN_TEST(test_close);  /* tear down */
-
-  MU_RUN_TEST(test_storage_plugin_unload_all);
 }
 
 

--- a/src/tests/test_storage.c
+++ b/src/tests/test_storage.c
@@ -134,14 +134,6 @@ MU_TEST(test_close)
 }
 
 
-MU_TEST(unload_plugins)
-{
-  dlite_storage_plugin_unload_all();
-}
-
-
-
-
 /***********************************************************************/
 
 
@@ -160,7 +152,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_load_all);
 
   MU_RUN_TEST(test_close);  /* teardown */
-  MU_RUN_TEST(unload_plugins);
 }
 
 int main()

--- a/storages/python/tests-c/test_blob_storage.c
+++ b/storages/python/tests-c/test_blob_storage.c
@@ -34,12 +34,6 @@ MU_TEST(test_save)
   mu_assert_int_eq(0, stat);
 }
 
-MU_TEST(test_unload_plugins)
-{
-  dlite_instance_decref(inst);
-  dlite_storage_plugin_unload_all();
-}
-
 
 /***********************************************************************/
 
@@ -47,7 +41,6 @@ MU_TEST_SUITE(test_suite)
 {
   MU_RUN_TEST(test_load);
   MU_RUN_TEST(test_save);
-  MU_RUN_TEST(test_unload_plugins);
 }
 
 int main()

--- a/storages/python/tests-c/test_bson_storage.c
+++ b/storages/python/tests-c/test_bson_storage.c
@@ -127,10 +127,6 @@ MU_TEST(test_load)
   while (dlite_instance_decref(bson_meta)); // Remove all json_meta references
 }
 
-MU_TEST(test_unload_plugins)
-{
-  dlite_storage_plugin_unload_all();
-}
 
 /****************************************************************************/
 
@@ -139,7 +135,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_for_bson);
   MU_RUN_TEST(test_save);
   MU_RUN_TEST(test_load);
-  MU_RUN_TEST(test_unload_plugins);
 }
 
 int main()

--- a/storages/python/tests-c/test_postgresql_storage.c
+++ b/storages/python/tests-c/test_postgresql_storage.c
@@ -106,13 +106,6 @@ MU_TEST(test_close_db)
 }
 
 
-MU_TEST(test_unload_plugins)
-{
-  dlite_storage_plugin_unload_all();
-}
-
-
-
 /***********************************************************************/
 
 
@@ -124,7 +117,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_load);
   MU_RUN_TEST(test_iter);
   MU_RUN_TEST(test_close_db);
-  MU_RUN_TEST(test_unload_plugins);
 }
 
 int main()

--- a/storages/python/tests-c/test_yaml_storage.c
+++ b/storages/python/tests-c/test_yaml_storage.c
@@ -48,14 +48,6 @@ MU_TEST(test_load)
   mu_assert_int_eq(0, dlite_storage_close(s));
 }
 
-MU_TEST(test_unload_plugins)
-{
-  dlite_storage_plugin_unload_all();
-}
-
-
-
-
 
 /***********************************************************************/
 
@@ -65,7 +57,6 @@ MU_TEST_SUITE(test_suite)
   MU_RUN_TEST(test_for_yaml);
   MU_RUN_TEST(test_save);
   MU_RUN_TEST(test_load);
-  MU_RUN_TEST(test_unload_plugins);
 }
 
 int main()


### PR DESCRIPTION
# Description
Removed functions dlite_storage_plugin_unload() and dlite_storage_plugin_unload_all() since they frees the underlying plugin, but leaves dangling pointers in the `api` field of the `DLiteStorage` structure, which later can course segfault.

Now, the only way to unload plugins, is to close the DLiteStorage.
This way we ensure that the memory management is handled correctly.

## Type of change
- [x] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
