### PR TITLE
Corrected treatment of strange symbols

### DIFF
--- a/bindings/python/dlite-jstore-python.i
+++ b/bindings/python/dlite-jstore-python.i
@@ -233,7 +233,9 @@ class _JSONEncoder(json.JSONEncoder):
           if id and id != uuid:
               d.setdefault("uri", id)
 
-          self.load_json(json.dumps(d, cls=_JSONEncoder))
+          # Keep Unicode literals (e.g. "°C") instead of ASCII escapes
+          # so downstream parsers receive the original unit symbols.
+          self.load_json(json.dumps(d, cls=_JSONEncoder, ensure_ascii=False))
 
       def get_dict(self, id=None, soft7=True, single=None, with_uuid=None,
                    with_meta=False, with_parent=True, urikey=False):

--- a/bindings/python/tests/input/datamodels.csv
+++ b/bindings/python/tests/input/datamodels.csv
@@ -1,3 +1,3 @@
 @id,description,title,datumName,datumType,datumUnit,datumMapping,datumName[x],datumType[x],datumShape[x]
-http://onto-ns.com/meta/test/0.1/m1,"First data model.","Datamodel 1",length,float64,cm,emmo:Length,,,
+http://onto-ns.com/meta/test/0.1/m1,"First data model.","Datamodel 1",temperature,float64,°C,emmo:Temperature,,,
 http://onto-ns.com/meta/test/0.1/m2,"Second data model.","Datamodel 2",key,string,,,indices,int,"N,M"

--- a/bindings/python/tests/test_table.py
+++ b/bindings/python/tests/test_table.py
@@ -51,8 +51,8 @@ m21, m22 = t2.get_datamodels()
 assert isinstance(m21, dlite.Metadata)
 assert isinstance(m22, dlite.Metadata)
 assert m21.description == "First data model."
-assert m21.getprop("length").type == "float64"
-assert m21.getprop("length").unit == "cm"
+assert m21.getprop("temperature").type == "float64"
+assert m21.getprop("temperature").unit == "°C"
 assert m22.getprop("key").type == "string"
 assert m22.getprop("indices").type == "int64"
 assert m22.getprop("indices").shape.tolist() == ["N", "M"]
@@ -115,11 +115,11 @@ if HAVE_TRIPPER and importcheck("rdflib"):
     assert ts.has(m1, RDFS.subClassOf, EMMO.Dataset)
     assert ts.has(m1, SKOS.prefLabel, en("M1"))
 
-    length = "http://onto-ns.com/meta/test/0.1/m1#length"
-    assert ts.has(length, RDF.type, OWL.Class)
-    assert ts.has(length, RDFS.subClassOf, EMMO.Datum)
-    assert ts.has(length, RDFS.subClassOf, EMMO.DoubleData)
-    assert ts.has(length, SKOS.prefLabel, en("Length"))
+    temp = "http://onto-ns.com/meta/test/0.1/m1#temperature"
+    assert ts.has(temp, RDF.type, OWL.Class)
+    assert ts.has(temp, RDFS.subClassOf, EMMO.Datum)
+    assert ts.has(temp, RDFS.subClassOf, EMMO.DoubleData)
+    assert ts.has(temp, SKOS.prefLabel, en("Temperature"))
 
 
 # Test invalid unit


### PR DESCRIPTION
# Description
Reading of special symbols was forced as Ascii which then broke things downstream (E.g. to_triplestore failed).
Updated tests to include this aspect.

## Type of change
- [ ] Bug fix & code cleanup
- [ ] New feature
- [ ] Documentation update
- [ ] Test update

## Checklist for the reviewer
This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
